### PR TITLE
Fix #70 - Permissions reset on setup-app

### DIFF
--- a/adhocracy/lib/install.py
+++ b/adhocracy/lib/install.py
@@ -30,7 +30,7 @@ def mk_perm(name, *groups):
     return perm
 
 
-def setup_entities():
+def setup_entities(initial_setup):
     #model.meta.Session.begin()
     model.meta.Session.commit()
 
@@ -49,71 +49,73 @@ def setup_entities():
 
     model.meta.Session.commit()
 
-    # ADD EACH NEW PERMISSION HERE
-    mk_perm("comment.create", advisor)
-    mk_perm("comment.delete", moderator)
-    mk_perm("comment.edit", advisor)
-    mk_perm("comment.show", anonymous)
-    mk_perm("comment.view", anonymous)
-    mk_perm("delegation.create", voter)
-    mk_perm("delegation.delete", voter)
-    mk_perm("delegation.show", anonymous)
-    mk_perm("delegation.view", anonymous)
-    mk_perm("global.admin", admins)
-    mk_perm("global.member", admins)
-    mk_perm("global.organization", organization)
-    mk_perm("instance.admin", supervisor)
-    mk_perm("instance.create", admins)
-    mk_perm("instance.delete", admins)
-    mk_perm("instance.index", anonymous)
-    mk_perm("instance.join", default)
-    mk_perm("instance.leave", default)
-    mk_perm("instance.news", anonymous)
-    mk_perm("instance.show", anonymous)
-    mk_perm("milestone.create", supervisor)
-    mk_perm("milestone.delete", supervisor)
-    mk_perm("milestone.edit", supervisor)
-    mk_perm("milestone.show", anonymous)
-    mk_perm("page.create", advisor)
-    mk_perm("page.delete", moderator)
-    mk_perm("page.edit", advisor)
-    mk_perm("page.show", anonymous)
-    mk_perm("page.view", anonymous)
-    mk_perm("poll.create", moderator)
-    mk_perm("poll.delete", moderator)
-    mk_perm("poll.show", anonymous)
-    mk_perm("proposal.create", advisor)
-    mk_perm("proposal.delete", moderator)
-    mk_perm("proposal.edit", advisor)
-    mk_perm("proposal.show", anonymous)
-    mk_perm("proposal.view", anonymous)
-    mk_perm("tag.create", advisor)
-    mk_perm("tag.delete", advisor)
-    mk_perm("tag.show", anonymous)
-    mk_perm("tag.view", anonymous)
-    mk_perm("user.edit", default)
-    mk_perm("user.manage", admins)
-    mk_perm("user.message", advisor)
-    mk_perm("user.show", anonymous)
-    mk_perm("user.view", anonymous)
-    mk_perm("vote.cast", voter)
-    mk_perm("vote.prohibit", organization)
-    mk_perm("watch.create", observer)
-    mk_perm("watch.delete", observer)
-    mk_perm("watch.show", anonymous)
+    if initial_setup:
 
-    model.meta.Session.commit()
-    # END PERMISSIONS LIST
+        # ADD EACH NEW PERMISSION HERE
+        mk_perm("comment.create", advisor)
+        mk_perm("comment.delete", moderator)
+        mk_perm("comment.edit", advisor)
+        mk_perm("comment.show", anonymous)
+        mk_perm("comment.view", anonymous)
+        mk_perm("delegation.create", voter)
+        mk_perm("delegation.delete", voter)
+        mk_perm("delegation.show", anonymous)
+        mk_perm("delegation.view", anonymous)
+        mk_perm("global.admin", admins)
+        mk_perm("global.member", admins)
+        mk_perm("global.organization", organization)
+        mk_perm("instance.admin", supervisor)
+        mk_perm("instance.create", admins)
+        mk_perm("instance.delete", admins)
+        mk_perm("instance.index", anonymous)
+        mk_perm("instance.join", default)
+        mk_perm("instance.leave", default)
+        mk_perm("instance.news", anonymous)
+        mk_perm("instance.show", anonymous)
+        mk_perm("milestone.create", supervisor)
+        mk_perm("milestone.delete", supervisor)
+        mk_perm("milestone.edit", supervisor)
+        mk_perm("milestone.show", anonymous)
+        mk_perm("page.create", advisor)
+        mk_perm("page.delete", moderator)
+        mk_perm("page.edit", advisor)
+        mk_perm("page.show", anonymous)
+        mk_perm("page.view", anonymous)
+        mk_perm("poll.create", moderator)
+        mk_perm("poll.delete", moderator)
+        mk_perm("poll.show", anonymous)
+        mk_perm("proposal.create", advisor)
+        mk_perm("proposal.delete", moderator)
+        mk_perm("proposal.edit", advisor)
+        mk_perm("proposal.show", anonymous)
+        mk_perm("proposal.view", anonymous)
+        mk_perm("tag.create", advisor)
+        mk_perm("tag.delete", advisor)
+        mk_perm("tag.show", anonymous)
+        mk_perm("tag.view", anonymous)
+        mk_perm("user.edit", default)
+        mk_perm("user.manage", admins)
+        mk_perm("user.message", advisor)
+        mk_perm("user.show", anonymous)
+        mk_perm("user.view", anonymous)
+        mk_perm("vote.cast", voter)
+        mk_perm("vote.prohibit", organization)
+        mk_perm("watch.create", observer)
+        mk_perm("watch.delete", observer)
+        mk_perm("watch.show", anonymous)
 
-    observer.permissions = observer.permissions + anonymous.permissions
-    advisor.permissions = advisor.permissions + observer.permissions
-    voter.permissions = voter.permissions + advisor.permissions
-    moderator.permissions = moderator.permissions + voter.permissions
-    supervisor.permissions = list(set(supervisor.permissions
-                               + moderator.permissions + advisor.permissions))
-    admins.permissions = admins.permissions + supervisor.permissions
-    organization.permissions = organization.permissions + observer.permissions
-    addressee.permissions = voter.permissions
+        model.meta.Session.commit()
+        # END PERMISSIONS LIST
+
+        observer.permissions = observer.permissions + anonymous.permissions
+        advisor.permissions = advisor.permissions + observer.permissions
+        voter.permissions = voter.permissions + advisor.permissions
+        moderator.permissions = moderator.permissions + voter.permissions
+        supervisor.permissions = list(set(supervisor.permissions
+                                   + moderator.permissions + advisor.permissions))
+        admins.permissions = admins.permissions + supervisor.permissions
+        organization.permissions = organization.permissions + observer.permissions
+        addressee.permissions = voter.permissions
 
     admin = model.User.find(u"admin")
     created_admin = False

--- a/adhocracy/websetup.py
+++ b/adhocracy/websetup.py
@@ -46,8 +46,10 @@ def _setup(config):
         db_version = migrateapi.db_version(url, migrate_repo)
         if db_version < repo_version:
             migrateapi.upgrade(url, migrate_repo)
+        initial_setup = False
     except DatabaseNotControlledError:
         meta.data.create_all(bind=meta.engine)
         migrateapi.version_control(url, migrate_repo, version=repo_version)
+        initial_setup = True
 
-    install.setup_entities()
+    install.setup_entities(initial_setup)


### PR DESCRIPTION
This commit changes the behavior of `setup-app`. Permissions are now
only set on initial call of `setup-app` and untouched on later calls,
e.g. when performing migration.

To determine whether we're currently performing an initial installation,
the current database state is used. This isn't pretty, but it should do
the job.
