### PR TITLE
Per-instance configuration for editable comments default (fixes #140)

### DIFF
--- a/adhocracy/controllers/instance.py
+++ b/adhocracy/controllers/instance.py
@@ -123,6 +123,8 @@ class InstanceContentsEditForm(formencode.Schema):
         not_empty=False, if_empty=False, if_missing=False)
     hide_global_categories = validators.StringBool(
         not_empty=False, if_empty=False, if_missing=False)
+    editable_comments_default = validators.StringBool(
+        not_empty=False, if_empty=False, if_missing=False)
 
 
 class InstanceVotingEditForm(formencode.Schema):
@@ -574,6 +576,7 @@ class InstanceController(BaseController):
                 'use_norms': instance.use_norms,
                 'require_selection': instance.require_selection,
                 'hide_global_categories': instance.hide_global_categories,
+                'editable_comments_default': instance.editable_comments_default,
                 'frozen': instance.frozen,
                 '_tok': csrf.token_id()})
 
@@ -589,7 +592,8 @@ class InstanceController(BaseController):
         updated = update_attributes(
             c.page_instance, self.form_result,
             ['allow_propose', 'allow_index', 'frozen', 'milestones',
-             'use_norms', 'require_selection', 'hide_global_categories'])
+             'use_norms', 'require_selection', 'hide_global_categories',
+             'editable_comments_default'])
         return self.settings_result(updated, c.page_instance, 'contents')
 
     def settings_voting_form(self, id):

--- a/adhocracy/migration/versions/043_instance_editable_comments_default.py
+++ b/adhocracy/migration/versions/043_instance_editable_comments_default.py
@@ -1,0 +1,52 @@
+from datetime import datetime
+from sqlalchemy import Column, ForeignKey, MetaData, Table, Float
+from sqlalchemy import Boolean, DateTime, Integer, Unicode, UnicodeText
+from sqlalchemy import func, or_
+
+metadata = MetaData()
+
+
+def upgrade(migrate_engine):
+    metadata.bind = migrate_engine
+    instance_table = Table('instance', metadata,
+          Column('id', Integer, primary_key=True),
+          Column('key', Unicode(20), nullable=False, unique=True),
+          Column('label', Unicode(255), nullable=False),
+          Column('description', UnicodeText(), nullable=True),
+          Column('required_majority', Float, nullable=False),
+          Column('activation_delay', Integer, nullable=False),
+          Column('create_time', DateTime, default=func.now()),
+          Column('access_time', DateTime, default=func.now(),
+                 onupdate=func.now()),
+          Column('delete_time', DateTime, nullable=True),
+          Column('creator_id', Integer, ForeignKey('user.id'),
+                 nullable=False),
+          Column('default_group_id', Integer, ForeignKey('group.id'),
+                 nullable=True),
+          Column('allow_adopt', Boolean, default=True),
+          Column('allow_delegate', Boolean, default=True),
+          Column('allow_propose', Boolean, default=True),
+          Column('allow_index', Boolean, default=True),
+          Column('hidden', Boolean, default=False),
+          Column('locale', Unicode(7), nullable=True),
+          Column('css', UnicodeText(), nullable=True),
+          Column('frozen', Boolean, default=False),
+          Column('milestones', Boolean, default=False),
+          Column('use_norms', Boolean, nullable=True, default=True),
+          Column('require_selection', Boolean, nullable=True, default=False),
+          Column('is_authenticated', Boolean, nullable=True, default=False),
+          Column('hide_global_categories', Boolean, nullable=True, default=False)
+          )
+
+    editable_comments = Column('editable_comments_default',
+                               Boolean,
+                               nullable=True,
+                               default=True)
+    editable_comments.create(instance_table)
+    u = instance_table.update(values={'editable_comments_default': True})
+    migrate_engine.execute(u)
+
+
+def downgrade(migrate_engine):
+    raise NotImplementedError()
+

--- a/adhocracy/model/instance.py
+++ b/adhocracy/model/instance.py
@@ -43,7 +43,8 @@ instance_table = \
           Column('use_norms', Boolean, nullable=True, default=True),
           Column('require_selection', Boolean, nullable=True, default=False),
           Column('is_authenticated', Boolean, nullable=True, default=False),
-          Column('hide_global_categories', Boolean, nullable=True, default=False)
+          Column('hide_global_categories', Boolean, nullable=True, default=False),
+          Column('editable_comments_default', Boolean, nullable=True, default=True)
           )
 
 

--- a/adhocracy/templates/comment/tiles.html
+++ b/adhocracy/templates/comment/tiles.html
@@ -272,13 +272,16 @@ klass_con = klass(-1)
 </%def>
 
 
-<%def name="create_form(parent, topic, wiki=True, arm=False, can_wiki=True, variant=None, ret_url='', format=None)">
+<%def name="create_form(parent, topic, wiki=None, arm=False, can_wiki=True, variant=None, ret_url='', format=None)">
 
 <%
 if format is None:
     format = ''
 else:
     format = ".%s" % format
+
+if wiki is None:
+    wiki = c.instance.editable_comments_default
 %>
   <h4>${_(u'Add comment')}</h4>
   <div class="comment_form">

--- a/adhocracy/templates/instance/settings_contents.html
+++ b/adhocracy/templates/instance/settings_contents.html
@@ -27,6 +27,7 @@
 
     ${forms.checkbox(_("Use milestones"), 'milestones', 15)}
     ${forms.checkbox(_("Hide global categories"), 'hide_global_categories', 17)}
+    ${forms.checkbox(_("Allow editing of comments by default"), 'editable_comments_default', 18)}
     ${forms.checkbox(_("Freeze this instance"), 'frozen', 20)}
     ${components.savebox("/instance/%s" % c.page_instance.key)}
 


### PR DESCRIPTION
This commit allows to configure on a per-instance base, whether commits
are by default editable by others, or not.

Note: Requires schema update.
