### PR TITLE
Do not allow HTML input

### DIFF
--- a/adhocracy/i18n/adhocracy.pot
+++ b/adhocracy/i18n/adhocracy.pot
@@ -1805,7 +1805,7 @@ msgstr ""
 msgid "The address may only contain alpha-numeric characters. Please note that this key cannot be changed after the instance has been created."
 msgstr ""
 
-msgid "Describe what the goals of this instance are and who constitutes its community. (Both Markdown and HTML are allowed here.)"
+msgid "Describe what the goals of this instance are and who constitutes its community."
 msgstr ""
 
 #, python-format

--- a/adhocracy/i18n/de/LC_MESSAGES/adhocracy.po
+++ b/adhocracy/i18n/de/LC_MESSAGES/adhocracy.po
@@ -1863,8 +1863,8 @@ msgstr "Die Adresse darf nur alphanumerische Zeichen enthalten. Bitte beachten S
 
 msgid ""
 "Describe what the goals of this instance are and who constitutes its "
-"community. (Both Markdown and HTML are allowed here.)"
-msgstr "Beschreiben Sie die Ziele dieser Gruppe und wer ihre Mitglieder sind. (Markdown und HTML sind hier erlaubt.)"
+"community."
+msgstr "Beschreiben Sie die Ziele dieser Gruppe und wer ihre Mitglieder sind."
 
 #, python-format
 msgid "Manage: %s"

--- a/adhocracy/i18n/en/LC_MESSAGES/adhocracy.po
+++ b/adhocracy/i18n/en/LC_MESSAGES/adhocracy.po
@@ -1857,8 +1857,8 @@ msgstr "The address may only contain alpha-numeric characters. Please note that 
 
 msgid ""
 "Describe what the goals of this instance are and who constitutes its "
-"community. (Both Markdown and HTML are allowed here.)"
-msgstr "Describe what the goals of this instance are and who constitutes its community. (Both Markdown and HTML are allowed here.)"
+"community."
+msgstr "Describe what the goals of this instance are and who constitutes its community."
 
 #, python-format
 msgid "Manage: %s"

--- a/adhocracy/i18n/fr/LC_MESSAGES/adhocracy.po
+++ b/adhocracy/i18n/fr/LC_MESSAGES/adhocracy.po
@@ -1859,8 +1859,8 @@ msgstr "Cette adresse ne peut contenir que des caractères alphanumériques. Rem
 
 msgid ""
 "Describe what the goals of this instance are and who constitutes its "
-"community. (Both Markdown and HTML are allowed here.)"
-msgstr "Décrivez les buts du groupe et le personne qui constitue ce communauté. (Markdown et HTML sont permits tous les deux.)"
+"community."
+msgstr "Décrivez les buts du groupe et le personne qui constitue ce communauté."
 
 #, python-format
 msgid "Manage: %s"

--- a/adhocracy/i18n/nl/LC_MESSAGES/adhocracy.po
+++ b/adhocracy/i18n/nl/LC_MESSAGES/adhocracy.po
@@ -1859,8 +1859,8 @@ msgstr "Het adres mag enkel bestaan uit alfanumerieke karakters. Houd er rekenin
 
 msgid ""
 "Describe what the goals of this instance are and who constitutes its "
-"community. (Both Markdown and HTML are allowed here.)"
-msgstr "Beschrijf de doelstellingen van deze groep en wie de deelnemers zijn (Zowel Markdown als HTML zijn hier toegestaan)."
+"community."
+msgstr "Beschrijf de doelstellingen van deze groep en wie de deelnemers zijn."
 
 #, python-format
 msgid "Manage: %s"

--- a/adhocracy/i18n/pl/LC_MESSAGES/adhocracy.po
+++ b/adhocracy/i18n/pl/LC_MESSAGES/adhocracy.po
@@ -1857,8 +1857,8 @@ msgstr "Adres może zawierać jedynie znaki alfanumeryczne. Po utworzeniu grupy 
 
 msgid ""
 "Describe what the goals of this instance are and who constitutes its "
-"community. (Both Markdown and HTML are allowed here.)"
-msgstr "Opisz, jakie są cele grupy i kto wchodzi w jej skład. (Dopuszczalne jest używanie znaczników Markdown i HTML.)"
+"community."
+msgstr "Opisz, jakie są cele grupy i kto wchodzi w jej skład."
 
 #, python-format
 msgid "Manage: %s"

--- a/adhocracy/i18n/ro/LC_MESSAGES/adhocracy.po
+++ b/adhocracy/i18n/ro/LC_MESSAGES/adhocracy.po
@@ -1858,8 +1858,8 @@ msgstr "Adresa poate contine doar caractere alfa-numerice. "
 
 msgid ""
 "Describe what the goals of this instance are and who constitutes its "
-"community. (Both Markdown and HTML are allowed here.)"
-msgstr "Descrie scopul comunitatii si cinear putea fi membrii ei (sunt permise si texte tip HTML)"
+"community."
+msgstr "Descrie scopul comunitatii si cinear putea fi membrii ei"
 
 #, python-format
 msgid "Manage: %s"

--- a/adhocracy/i18n/ru/LC_MESSAGES/adhocracy.po
+++ b/adhocracy/i18n/ru/LC_MESSAGES/adhocracy.po
@@ -1861,8 +1861,8 @@ msgstr "Адрес может содержать только буквы или 
 
 msgid ""
 "Describe what the goals of this instance are and who constitutes its "
-"community. (Both Markdown and HTML are allowed here.)"
-msgstr "Опишите цели этой организации и кто ее составляет (Разрешена как вики-маркировка, так и HTML)"
+"community."
+msgstr "Опишите цели этой организации и кто ее составляет"
 
 #, python-format
 msgid "Manage: %s"

--- a/adhocracy/lib/text/__init__.py
+++ b/adhocracy/lib/text/__init__.py
@@ -31,8 +31,8 @@ def meta_escape(text, markdown=True):
     return text
 
 
-def markdown_to_plain_text(markup, safe_mode=False):
-    html = render(markup, substitutions=False, safe_mode=safe_mode)
+def markdown_to_plain_text(markup):
+    html = render(markup, substitutions=False)
     try:
         return fragment_fromstring(html, create_parent=True).text_content()
     except Exception, e:

--- a/adhocracy/lib/text/render.py
+++ b/adhocracy/lib/text/render.py
@@ -46,11 +46,11 @@ def render(text, substitutions=True, safe_mode='escape'):
         @(pudo), to html.
     *safe_mode*
         This is passed directly to the markdown renderer. Possible options are
-        `'escape'` (escape html tags), `'remove'` (remove html tags) and
-        `False`(allow html tags).
+        `'escape'` (escape html tags) and `'remove'` (remove html tags).
     '''
     if text is None:
         return ""
+    assert safe_mode in ('escape', 'remove')
     text = markdown.markdown(
         text,
         extensions=[

--- a/adhocracy/lib/tiles/instance_tiles.py
+++ b/adhocracy/lib/tiles/instance_tiles.py
@@ -21,7 +21,7 @@ class InstanceTile(BaseTile):
     @property
     def description(self):
         if self.instance.description:
-            return text.render(self.instance.description, safe_mode=False)
+            return text.render(self.instance.description)
         return ""
 
     @property

--- a/adhocracy/lib/tiles/milestone_tiles.py
+++ b/adhocracy/lib/tiles/milestone_tiles.py
@@ -14,7 +14,7 @@ class MilestoneTile(BaseTile):
     @property
     def text(self):
         if self.milestone.text:
-            return text.render(self.milestone.text, safe_mode=False)
+            return text.render(self.milestone.text)
         return ""
 
 

--- a/adhocracy/templates/instance/new.html
+++ b/adhocracy/templates/instance/new.html
@@ -36,7 +36,7 @@
       <legend>${_("Description")}</legend>
       <p class="info">
       ${_("Describe what the goals of this instance are and who constitutes "
-          "its community. (Both Markdown and HTML are allowed here.)")} 
+          "its community.")} 
       </p>
       <textarea tabindex="3" class="description" name="description"></textarea>
       ${components.formatting()}

--- a/adhocracy/templates/instance/settings_general.html
+++ b/adhocracy/templates/instance/settings_general.html
@@ -22,7 +22,7 @@
     ${forms.input(_("Name"), 'label', 1)}
     
     <%forms:textarea label="${_('Description')}" name="description" value="" tabindex="5"
-    help="${_('Describe what the goals of this instance are and who constitutes its community. (Both Markdown and HTML are allowed here.)')}">
+    help="${_('Describe what the goals of this instance are and who constitutes its community.')}">
     ${components.formatting()}    
     </%forms:textarea>
 


### PR DESCRIPTION
As of f1632cca1160eae2f6e3b2612e26aada5d203760 (and before 13ab01a4488e4e2f8d396e913fee00bdb46adf88), instance administrators can inject arbitrary HTML into an application.

If relative_urls is on, this allows instance administrators to trivially execute JavaScript in the installation's origin.
But even if it's off, instance administrators can trivially:
- Steal users' session cookies (And vote as them in other instances!)
- Out-right ask users for their passwords.
- Switch out links to other parts of the UI

http://sectest.adhocracy.de/ demonstrates this (try clicking one of the navigation links).

Therefore, we should forbid HTML in instance and milestone texts. This pull request does exactly that.
