### PR TITLE
Remove fanstatic_url helper

### DIFF
--- a/adhocracy/lib/helpers/__init__.py
+++ b/adhocracy/lib/helpers/__init__.py
@@ -38,7 +38,6 @@ from adhocracy.lib.helpers import abuse_helper as abuse, tutorial
 from adhocracy.lib.helpers import milestone_helper as milestone
 from adhocracy.lib.helpers import recaptcha_helper as recaptcha
 from adhocracy.lib.helpers.fanstatic_helper import (FanstaticNeedHelper,
-                                                    FanstaticUrlHelper,
                                                     get_socialshareprivacy_url)
 from adhocracy.lib.helpers import feedback_helper as feedback
 from adhocracy.lib.helpers.url import build
@@ -53,7 +52,6 @@ from adhocracy.i18n import relative_date, relative_time
 flash = _Flash()
 recaptcha = recaptcha.Recaptcha()
 need = FanstaticNeedHelper(static)
-fanstatic_url = FanstaticUrlHelper(static)
 
 
 def allow_user_registration():

--- a/adhocracy/lib/helpers/fanstatic_helper.py
+++ b/adhocracy/lib/helpers/fanstatic_helper.py
@@ -43,29 +43,3 @@ class FanstaticNeedHelper(object):
 
     def __getattr__(self, name):
         return _get_resource(self.module, name).need()
-
-
-class FanstaticUrlHelper(object):
-    '''
-    A helper class to access fanstatic resource urls
-    defined in :module:`adhocracy.static`
-
-    Use it this way::
-
-        from adhocracy import static
-        fanstatic_url = FanstaticUrlHelper(static)
-        fanstatic_url.stylesheets
-
-    where "stylesheets" is a fanstatic Resource defined in adhocracy.static.
-    '''
-
-    def __init__(self, module):
-        self.module = module
-
-    def __getattr__(self, name):
-        resource = _get_resource(self.module, name)
-
-        return '%s/%s' % (
-            fanstatic.get_needed().library_url(resource.library),
-            resource.relpath
-        )


### PR DESCRIPTION
Surprisingly, removing this chunk of code has no effect.

I could not find any usage of `fanstatic_url` (or `FanstaticUrlHelper`), tests pass, and everything looks as before.
