### PR TITLE
Do not require admin to verify address

### DIFF
--- a/adhocracy/lib/install.py
+++ b/adhocracy/lib/install.py
@@ -128,6 +128,7 @@ def setup_entities(initial_setup):
         admin = model.User.create(ADMIN, u'',
                                   password=ADMIN_PASSWORD,
                                   global_admin=True)
+        admin.activation_code = None
 
     model.meta.Session.commit()
 


### PR DESCRIPTION
Currently, the admin has to verify the email address. This is inconvenient to do for developers and users alike. Therefore, we should default the admin to already have a verified address.
