### PR TITLE
Make testrecorder optional

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -19,9 +19,10 @@ extends =
 #    buildouts/adhocracy_with_theming.cfg
 #development-extends (please comment for production):
     buildouts/developtools.cfg
+#   buildouts/testrecorder.cfg
     buildouts/codecheck.cfg
     buildouts/mailserver.cfg
-    versions.cfg 
+    versions.cfg
 #productive-extends: 
 #    buildouts/postgres.cfg
 #    buildouts/adhocracy_setup_database.cfg 

--- a/buildouts/developtools.cfg
+++ b/buildouts/developtools.cfg
@@ -4,9 +4,6 @@
 ##############################################################################
 
 [buildout]
-extends =
-# we need zope only to make zope.testrecorder run, if you have problems, just delete it
-    http://good-py.appspot.com/release/zope/2.13.12
 parts +=
     adhocpy
     omelette
@@ -15,8 +12,6 @@ parts +=
     test
     coveragereport
     sphinxbuilder
-    instance
-    testrecorder
 
 # Pull und update each package to get the newest versions
 #always-checkout = true
@@ -115,25 +110,3 @@ defaults =
 [coveragereport]
 recipe = zc.recipe.egg
 eggs = createcoverage
-
-##############################################################################
-# Testbrowser recorder
-##############################################################################
-
-[instance]
-recipe = plone.recipe.zope2instance
-user = test:test
-http-address = 8088
-eggs =
-  zope.testrecorder
-zcml =
-  zope.testrecorder
-
-[testrecorder]
-# start your local adhocracy server
-# run bin/testrecorder_start to open you browser
-# submit the local adhocracy server url
-# record a use_case/acceptance test run - http://plone.org/documentation/kb/testing/zope-testrecorder
-recipe = plone.recipe.command
-command = echo 'xdg-open "http:localhost:${instance:http-address}/++resource++recorder/index.html"' > bin/testrecorder.sh
-          chmod a+x bin/testrecorder.sh

--- a/buildouts/testrecorder.cfg
+++ b/buildouts/testrecorder.cfg
@@ -1,0 +1,34 @@
+##############################################################################
+#  testrecorder, a legacy tool to create integration tests
+##############################################################################
+
+[buildout]
+extends =
+# we need zope only to make zope.testrecorder run, if you have problems, just delete it
+    http://good-py.appspot.com/release/zope/2.13.12
+
+parts +=
+	instance
+    testrecorder
+
+##############################################################################
+# Testbrowser recorder
+##############################################################################
+
+[instance]
+recipe = plone.recipe.zope2instance
+user = test:test
+http-address = 8088
+eggs =
+  zope.testrecorder
+zcml =
+  zope.testrecorder
+
+[testrecorder]
+# start your local adhocracy server
+# run bin/testrecorder_start to open you browser
+# submit the local adhocracy server url
+# record a use_case/acceptance test run - http://plone.org/documentation/kb/testing/zope-testrecorder
+recipe = plone.recipe.command
+command = echo 'xdg-open "http:localhost:${instance:http-address}/++resource++recorder/index.html"' > bin/testrecorder.sh
+          chmod a+x bin/testrecorder.sh


### PR DESCRIPTION
Unlike the other testtools, testrecorder is not in any way required to develop adhocracy. Additionally, it comes not only with its own swath of version pinnings, but also numerous dependencies. On Amazon AWS Micro machines, this change speeds up the build process by about 5 minutes (from 16m8s to 10m47s).
