### PR TITLE
Show link to weberror interactive debugger in debug mode

### DIFF
--- a/etc/adhocracy.ini.in
+++ b/etc/adhocracy.ini.in
@@ -148,6 +148,11 @@ sqlalchemy.url = ${parts.adhocracy['sqlalchemy.url']}
 
 adhocracy.solr.url = http://${parts.solr.host}:${parts.solr.port}/solr
 
+# If debug is enabled, an web-based interactive debugger can be executed from
+# the HTTP500 error page, if the following option is set to true. This option
+# doesn't have any effect if debug is false.
+adhocracy.interactive_debugging = true
+
 # WARNING: *THE LINE BELOW MUST BE UNCOMMENTED ON A PRODUCTION ENVIRONMENT*
 # Debug mode will enable the interactive debugging tool, allowing ANYONE to
 # execute malicious code after an exception is raised.

--- a/src/adhocracy/controllers/error.py
+++ b/src/adhocracy/controllers/error.py
@@ -3,7 +3,9 @@ import re
 
 from pylons import request, response, tmpl_context as c
 from pylons.i18n import _
+from pylons import config
 
+from paste.deploy.converters import asbool
 from paste.urlparser import PkgResourcesParser
 from pylons.controllers.util import forward
 
@@ -42,6 +44,16 @@ class ErrorController(BaseController):
 
         if not c.error_message:
             c.error_message = _("Error %s") % c.error_code
+
+        if asbool(config.get('adhocracy.interactive_debugging', 'false')):
+            c.trace_url = request.environ['pylons.original_response']\
+                .headers.get('X-Debug-URL', None)
+
+            if c.trace_url is not None:
+                # this may only happen in debug mode
+                assert(asbool(config.get('debug', 'false')))
+        else:
+            c.trace_url = None
 
         return render("/error/http.html")
 

--- a/src/adhocracy/templates/error/http.html
+++ b/src/adhocracy/templates/error/http.html
@@ -7,5 +7,9 @@
 
 <strong>${c.error_message|n}</strong>
 
+%if c.trace_url:
+<a href="${c.trace_url}">trace me</a>
+%endif
+
 <p>${_("If this error continues to occur, please <a class='staticlink_imprint' href='/static/imprint.html'>notify the developers</a> with a description of what you were trying to do.")|n} ${_("An automated email message describing the situation has been sent to our developers.")}</p>
 </%block>


### PR DESCRIPTION
Weberror allows for interactive post-mortem debugging. The respective
middleware has already been active in available previously.

This commit allows to expose a link to the interactive debugging session
from the HTTP500 error page through the configuration option
`adhocracy.interactive_debugging`.

See the [Pylons docs](https://pylons-webframework.readthedocs.org/en/latest/debugging.html#interactive-debugging).

I think this is very new-developer-friendly, so I propose to enable this by default (in debug mode).
