### PR TITLE
Remove werkzeug dependency

### DIFF
--- a/buildouts/developtools.cfg
+++ b/buildouts/developtools.cfg
@@ -25,7 +25,6 @@ eggs +=
     Babel
     ipython
     ipdb
-    Werkzeug
     WebError
 
 [paster]


### PR DESCRIPTION
I thought `werkzeug` is in the developers toolchain because of the interactive debugging, but this seems to be covered by Pylons weberror.

Is there any reason to keep `werkzeug` in? @joka, do you know why this was in at the first place?

If not, this PR removes it from the developer buildout.
