### PR TITLE
Start lamson mail logger with supervisord (fixes #233)

### DIFF
--- a/buildouts/mailserver.cfg
+++ b/buildouts/mailserver.cfg
@@ -11,7 +11,7 @@ parts +=
     mailserver_bin
 
 lamson-supervisor =   
-    25 lamson (redirect_stderr=true stdout_logfile=var/log/lamson.log stderr_logfile=NONE) ${buildout:directory}/bin/lamson-logger.py
+    25 lamson (redirect_stderr=true stdout_logfile=var/log/lamson.log stderr_logfile=NONE) ${buildout:directory}/bin/lamson-logger
 
 
 [ports]
@@ -19,19 +19,16 @@ mailserver_port = 8825
 
 
 [lamson]
-recipe = minitage.recipe.du
-url = http://pypi.python.org/packages/source/l/lamson/lamson-1.1.tar.gz
-bin = ${buildout:parts-directory}/lamson/bin
+recipe = minitage.recipe.scripts
+eggs = lamson
 
 
 [mailserver_install]
 recipe = plone.recipe.command
 command =
-# we install the lamson mailserver with the system python because the lamson egg has no setuptool support
-# http://lamsonproject.org/docs/getting_started.html
 # generate lamson projekt
     cd ${buildout:parts-directory}
-    ${lamson:bin}/lamson gen -project mailserver -FORCE
+    ${buildout:directory}/bin/lamson gen -project mailserver -FORCE
 # how to use the lamson mailserver
     echo -e "\n\nLAMSON MAILSERVER LOGGER\n\n"
 
@@ -43,18 +40,16 @@ update-command = ${mailserver_install:command}
 
 
 [mailserver_bin]
-recipe = collective.recipe.template
-input = inline:
-    #!/usr/bin/env python
-
-    from lamson import utils
-    import sys, os
-     
-    os.chdir('${buildout:directory}/parts/mailserver')
-    settings = utils.make_fake_settings('127.0.0.1', ${ports:mailserver_port})
-    settings.receiver.start()
-output = ${buildout:bin-directory}/lamson-logger.py
-mode = 755
+recipe = minitage.recipe.scripts
+eggs = lamson
+initialization =
+        import sys, os
+        from lamson import utils
+        os.chdir('${buildout:directory}/parts/mailserver')
+        settings = utils.make_fake_settings('127.0.0.1', ${ports:mailserver_port})
+        settings.receiver.start()
+interpreter = lamson-logger
+scripts = lamson-logger
 
 
 [supervisor]

--- a/versions.cfg
+++ b/versions.cfg
@@ -76,6 +76,8 @@ js.jquery = 1.7.2
 js.jquery-qtip = 1.0.0
 js.socialshareprivacy = 1.3-1
 
+lamson = 1.3.1
+
 #lamson and some other packages
 Jinja2 = 2.6
 


### PR DESCRIPTION
Can someone please confirm that this is working on another machine than mine as well? The installation of lamson in `parts/site-packages` is a bit strange, but seems to be working.

Tnx!

---

This uses a custom method of starting lamson in logging mode, which does
not daemonize lamson [0].

Mailserver logs end up in `parts/mailserver/logs/logger.log` instead of
`var/log/lamson.log`. This could be changed by calling the stuff from
`lamson.utils.make_settings` manually, but I think it's not worth it.

[0] https://gist.github.com/nidico/5076333
