### PR TITLE
Hide category selection if no categories exist.

### DIFF
--- a/src/adhocracy/templates/proposal/new.html
+++ b/src/adhocracy/templates/proposal/new.html
@@ -24,7 +24,9 @@
       </div>
     </fieldset>
 
+    %if c.categories:
     ${components.category_select('category_select', c.toplevel_question, c.categories)}
+    %endif
     
     %if c.instance.use_norms:
     <fieldset>          


### PR DESCRIPTION
If no category can be selected, the selection does not need to be shown. Simplifies the proposal creation screen a little.
