### PR TITLE
Add config option to control whether abuse button is visible.

### DIFF
--- a/buildouts/hhu.cfg
+++ b/buildouts/hhu.cfg
@@ -55,6 +55,7 @@ settings_override =
     adhocracy.client_location = ${buildout:directory}/src/adhocracy.hhu_theme/
     adhocracy.show_stats_on_frontpage = False
     adhocracy.enable_gender = True
+    adhocracy.show_abuse_button = False
     adhocracy.requestlog_active = True
     adhocracy.requestlog_ipanonymization = none
     adhocracy.monitor_comment_behavior = True

--- a/src/adhocracy/templates/comment/tiles.html
+++ b/src/adhocracy/templates/comment/tiles.html
@@ -176,8 +176,10 @@
             </div>
             <div class="utility">
                 <span style="display: none;" class="hover_active">
+                    %if h.asbool(config.get('adhocracy.show_abuse_button', 'True')):
                     <a href="${h.abuse.for_entity(comment)}">${_("report")}</a>
                     · 
+                    %endif
                     %if len(comment.revisions) > 1:
                     <span class="only-js"> 
                         ## FIXME: remove when we can support no-js clients.

--- a/src/adhocracy/templates/proposal/show.html
+++ b/src/adhocracy/templates/proposal/show.html
@@ -76,10 +76,12 @@ delegate_url = url if can.delegation.create() else None
                         ${_("%s Proposed Implementations") % len(c.num_selections)}
                     </a>
                     %endif
+                    %if h.asbool(config.get('adhocracy.show_abuse_button', 'True')):
                     · 
                     <a href="${h.abuse.for_entity(c.proposal)}">
                         ${_("report")}
                     </a>
+                    %endif
                     ·
                     <a href="${c.history_url}"
                        rel="#overlay-ajax">${'history'}</a>

--- a/src/adhocracy/templates/proposal/tiles.html
+++ b/src/adhocracy/templates/proposal/tiles.html
@@ -40,7 +40,9 @@
     <h3>${_("Information")}</h3>
     <div>
         ${_("The proposal was created by %s on %s") % (h.user.link(proposal.creator), h.format_date(proposal.create_time))|n} 
+      %if h.asbool(config.get('adhocracy.show_abuse_button', 'True')):
     · <a href="${h.abuse.for_entity(proposal)}">${_("report")}</a>
+      %endif
   </div>
   %if proposal.milestone and c.instance.milestones:
   <br/>


### PR DESCRIPTION
Option is called 'adhocracy.show_abuse_button' and set to True by default and False for the HHU theme. Needed for hhucn/adhocracy.hhu_theme#205.
