### PR TITLE
Fix page monitoring to include full request URL

### DIFF
--- a/src/adhocracy/lib/base.py
+++ b/src/adhocracy/lib/base.py
@@ -48,9 +48,7 @@ class BaseController(WSGIController):
                 config.get('adhocracy.monitor_page_time_interval', -1))
         if monitor_page_time_interval > 0:
             c.monitor_page_time_interval = monitor_page_time_interval
-            c.monitor_page_time_url = '%s?%s' % (
-                h.base_url('/stats/on_page'),
-                urllib.urlencode({'path': request.url}))
+            c.monitor_page_time_url = h.base_url('/stats/on_page')
 
         h.add_rss("%s News" % h.site.name(),
                   h.base_url('/feed.rss', None))

--- a/src/adhocracy/static/javascripts/adhocracy.js
+++ b/src/adhocracy/static/javascripts/adhocracy.js
@@ -501,7 +501,7 @@ $(document).ready(function () {
         $(window).blur( function() { window_is_active = false });
         var stats_interval = $('body').data('stats-interval');
         var sendOnPagePing = function() {
-            $.get(page_stats_baseurl + '&window_is_active=' + window_is_active,
+            $.get(page_stats_baseurl + '?page=' + encodeURIComponent(location.href) + '&window_is_active=' + window_is_active,
                     null, setOnPageTimeout);
         };
         var setOnPageTimeout = function() {


### PR DESCRIPTION
The monitoring process for the time spent on a page logs only a partial
URL. This is fixed by using location.href when submitting the background
request.
