### PR TITLE
Disallow OpenID signup when user registration is disabled

### DIFF
--- a/src/adhocracy/controllers/openidauth.py
+++ b/src/adhocracy/controllers/openidauth.py
@@ -245,6 +245,14 @@ class OpenidauthController(BaseController):
                 redirect(h.entity_url(c.user, member='edit'))
             else:
 
+                if not h.allow_user_registration():
+                    h.flash(_(
+                        "OpenID %s doesn't belong to an existing user account "
+                        "and user registration is disabled in this "
+                        "installation." % info.identity_url
+                    ), 'warning')
+                    redirect(h.base_url('/login'))
+
                 user_by_email = model.User.find_by_email(email)
                 if user_by_email is not None:
                     if is_trusted_provider(info.identity_url):

--- a/src/adhocracy/templates/openid/form.html
+++ b/src/adhocracy/templates/openid/form.html
@@ -2,7 +2,13 @@
    <label for="openid">${_('Alternative')}:</label>
    <div id="openid_choice">
       %if c.openid_scenario and c.openid_scenario == "login":
-         <span class="hint">${_('Login with your OpenID to skip registration.')}</span>
+         <span class="hint">
+           %if h.allow_user_registration():
+           ${_('Login with your OpenID to skip registration.')}
+           %else:
+           ${_('Login with your OpenID.')}
+           %endif
+         </span>
       %endif
       <div id="openid_btns"></div>
    </div>


### PR DESCRIPTION
Note that connecting existing users to OpenID and sign in with an existing OpenID connection is still possible.
