### PR TITLE
Readd missing title part (fixes #125)

### DIFF
--- a/src/adhocracy/templates/components.html
+++ b/src/adhocracy/templates/components.html
@@ -144,8 +144,6 @@
     %endif
 </%def>
 
-<%def name="title()"></%def>
-
 
 <%def name="vertical_tabs(items, css_class, current_variant=None)">
 <nav>
@@ -185,14 +183,16 @@ $(document).ready(function () {
 </%def>
 
 
-<%def name="head()">
+<%def name="head(title_def)">
   <meta charset="utf-8" />
-    <title>${'self.title() - ' if self.title() else ''}
-            %if c.instance:
-                 ${c.instance.label} -
-            %endif
-                ${h.site.name()}
-    </title>
+    <%
+    local_title = capture(title_def)
+    full_title = '%s%s%s' % (
+        local_title + ' - ' if local_title else '',
+        c.instance.label + ' - ' if c.instance else '',
+        h.site.name())
+    %>
+    <title>${full_title}</title>
 
     <meta http-equiv="X-XRDS-Location" 
           content="${h.base_url('/openid/xrds', absolute=True)}" />

--- a/src/adhocracy/templates/root.html
+++ b/src/adhocracy/templates/root.html
@@ -2,12 +2,12 @@
 /><%namespace name="components" file="/components.html"
 /><%namespace name="navigation" file="/navigation.html"
 /><%namespace name="debug" file="/debug/tiles.html"
-/><%def name="breadcrumbs()">&nbsp;</%def><?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+/><%def name="breadcrumbs()">&nbsp;</%def><%def name="title()"></%def><?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <!DOCTYPE html>
 <html class="no-js">
   <head>
       <%block name="head">
-      ${components.head()}
+      ${components.head(self.title)}
       </%block>
 
       %if h.config.get('adhocracy.debug.sql'):


### PR DESCRIPTION
This adds the dynamic part of the title header again, which had been
broken in e1d45a6778e56d588c276a174db56577626c139b.
