### PR TITLE
Experimental flag for secret voting

### DIFF
--- a/buildouts/hhu.cfg
+++ b/buildouts/hhu.cfg
@@ -73,5 +73,4 @@ settings_override =
     adhocracy.instances.autojoin = ALL
     adhocracy.login_type = email+password
     adhocracy.self_deletion_allowed = false
-    adhocracy.secret_voting = true
-
+    adhocracy.hide_individual_votes = true

--- a/etc/adhocracy.ini.in
+++ b/etc/adhocracy.ini.in
@@ -283,7 +283,7 @@ piwik.id =
 # adhocracy.enable_welcome = True
 
 # INSTALL: Hide individual votes and only show aggregate results (EXPERIMENTAL)
-# adhocracy.secret_voting = true
+# adhocracy.hide_individual_votes = true
 
 # INSTALL: Allow users to lock themselves out of adhocracy
 # adhocracy.allow_self_deletion = true

--- a/src/adhocracy/controllers/poll.py
+++ b/src/adhocracy/controllers/poll.py
@@ -77,7 +77,7 @@ class PollController(BaseController):
         votes = decision.make(self.form_result.get("position"))
         model.meta.Session.commit()
 
-        if not asbool(config.get('adhocracy.secret_voting', 'false')):
+        if not asbool(config.get('adhocracy.hide_individual_votes', 'false')):
             for vote in votes:
                 event.emit(event.T_VOTE_CAST, vote.user, instance=c.instance,
                            topics=[c.poll.scope], vote=vote, poll=c.poll)
@@ -118,7 +118,7 @@ class PollController(BaseController):
                       }.get(c.poll.action)
         model.meta.Session.commit()
 
-        if not asbool(config.get('adhocracy.secret_voting', 'false')):
+        if not asbool(config.get('adhocracy.hide_individual_votes', 'false')):
             for vote in votes:
                 event.emit(event_type, vote.user, instance=c.instance,
                            topics=[c.poll.scope], vote=vote, poll=c.poll)

--- a/src/adhocracy/lib/auth/poll.py
+++ b/src/adhocracy/lib/auth/poll.py
@@ -10,8 +10,8 @@ def index(check):
 def show(check, p):
     check.perm('poll.show')
     check.other('poll_has_ended', p.has_ended())
-    secret_voting = asbool(config.get('adhocracy.secret_voting', 'false'))
-    check.other('secret_voting', secret_voting)
+    hide_cfg = asbool(config.get('adhocracy.hide_individual_votes', 'false'))
+    check.other('hide_individual_votes', hide_cfg)
 
 
 def create(check):


### PR DESCRIPTION
In some installations, users do not want that their peers can see how they voted. Of course, this means the users have to trust the system administrator not to reveal votes. Nevertheless, the new configuration flag `adhocracy.secret_voting` should allow votes to stay secret and with minimal code impact.
