### PR TITLE
Make massmessage footer optional

### DIFF
--- a/src/adhocracy/controllers/massmessage.py
+++ b/src/adhocracy/controllers/massmessage.py
@@ -36,6 +36,7 @@ class MassmessageForm(formencode.Schema):
     filter_instances = forms.MessageableInstances()
     filter_badges = forms.ValidUserBadges()
     sender = validators.String(not_empty=True)
+    include_footer = formencode.validators.StringBoolean(if_missing=False)
 
 
 def _get_options(func):
@@ -65,12 +66,17 @@ def _get_options(func):
                                          UserBadges.user_id == User.id)
             recipients = recipients.filter(
                 UserBadges.badge_id.in_([fb.id for fb in filter_badges]))
+        if has('global.admin'):
+            include_footer = self.form_result.get('include_footer')
+        else:
+            include_footer = True
 
         return func(self,
                     allowed_sender_options[sender]['email'],
                     self.form_result.get('subject'),
                     self.form_result.get('body'),
                     recipients,
+                    include_footer,
                     )
     return wrapper
 
@@ -133,6 +139,7 @@ class MassmessageController(BaseController):
             template = '/instance/settings_massmessage.html'
 
         defaults = dict(request.params)
+        defaults.setdefault('include_footer', 'on')
 
         data = {
             'instances': self.get_allowed_instances(c.user),
@@ -146,11 +153,12 @@ class MassmessageController(BaseController):
                                force_defaults=False)
 
     @_get_options
-    def preview(self, sender, subject, body, recipients):
+    def preview(self, sender, subject, body, recipients, include_footer):
         recipients_list = sorted(list(recipients), key=lambda r: r.name)
         if recipients_list:
             try:
-                rendered_body = render_body(body, recipients[0])
+                rendered_body = render_body(body, recipients_list[0],
+                                            include_footer)
             except (KeyError, ValueError) as e:
                 rendered_body = _('Could not render message: %s') % str(e)
         else:
@@ -163,15 +171,17 @@ class MassmessageController(BaseController):
             'recipients': recipients_list,
             'recipients_count': len(recipients_list),
             'params': request.params,
+            'include_footer': include_footer,
         }
         return render('/massmessage/preview.html', data)
 
     @_get_options
-    def create(self, sender, subject, body, recipients):
+    def create(self, sender, subject, body, recipients, include_footer):
         message = Message.create(subject,
                                  body,
                                  c.user,
-                                 sender)
+                                 sender,
+                                 include_footer)
 
         for count, user in enumerate(recipients, start=1):
             MessageRecipient.create(message, user, notify=True)

--- a/src/adhocracy/lib/message.py
+++ b/src/adhocracy/lib/message.py
@@ -1,23 +1,37 @@
 from adhocracy.i18n import _
 from adhocracy.lib.helpers import base_url
 
+from pylons import config
+
 
 def _make_welcome_link(user):
     return base_url("/welcome/%s/%s" % (user.user_name, user.welcome_code),
                     absolute=True)
 
 
-def render_body(body, user):
-    if user.gender == 'f':
+def render_body(body, recipient, include_footer):
+    from adhocracy.lib import helpers as h
+    from adhocracy.lib.templating import render
+
+    if recipient.gender == 'f':
         salutation = _('Dear Ms.')
-    elif user.gender == 'm':
+    elif recipient.gender == 'm':
         salutation = _('Dear Mr.')
     else:
         salutation = _('Dear')
 
-    return body.format(**{
-        'name': user.name,
-        'email': user.email,
-        'welcome_link': _make_welcome_link(user),
+    rendered_body = body.format(**{
+        'name': recipient.name,
+        'email': recipient.email,
+        'welcome_link': _make_welcome_link(recipient),
         'salutation': salutation,
+    })
+
+    return render("/massmessage/body.txt", {
+        'body': rendered_body,
+        'page_url': config.get('adhocracy.domain').strip(),
+        'settings_url': h.entity_url(recipient,
+                                     member='edit',
+                                     absolute=True),
+        'include_footer': include_footer,
     })

--- a/src/adhocracy/migration/versions/061_optional_massmessage_footer.py
+++ b/src/adhocracy/migration/versions/061_optional_massmessage_footer.py
@@ -1,0 +1,12 @@
+from sqlalchemy import MetaData, Table, Boolean, Column
+
+from sqlalchemy import Integer
+
+
+def upgrade(migrate_engine):
+    meta = MetaData(bind=migrate_engine)
+
+    message_table = Table('message', meta, autoload=True)
+    col = Column('include_footer', Boolean, nullable=False, default=True,
+                 server_default="true")
+    col.create(message_table)

--- a/src/adhocracy/templates/massmessage/body.txt
+++ b/src/adhocracy/templates/massmessage/body.txt
@@ -1,4 +1,5 @@
 ${c.body|n}
-
+%if c.include_footer:
 --
 ${_("You receive this message because you're signed in to the news service on %s. You can change your subscription settings on the following page: %s") % (c.page_url, c.settings_url) | n}
+%endif

--- a/src/adhocracy/templates/massmessage/new.html
+++ b/src/adhocracy/templates/massmessage/new.html
@@ -32,13 +32,23 @@
 
       <fieldset>
         <legend>${_("Subject")}</legend>
-        <input name="subject" />
+        <input name="subject" required="required" />
       </fieldset>
 
       <fieldset>
         <legend>${_("Body")}</legend>
-        <textarea name="body"></textarea>
+        <textarea name="body" required="required"></textarea>
         <div>${_('Use {email}, {name}, {salutation} to address the user directly.')}</div>
+
+        %if lib.auth.authorization.has('global.admin'):
+          <label title="${_('Add a note about why the user got this message, and how to unsubscribe.') + u'\n' + _('Uncheck if user management is centralized.')}">
+          <input type="checkbox" name="include_footer" /> ${_('Include footer')}
+          </label>
+        %else:
+          ## Just for reference; this will be set to true anyways unless user gains
+          ## global.admin privileges in between rendering this form and submission
+          <input type="hidden" name="include_footer" checked="checked" />
+        %endif
       </fieldset>
 
       <fieldset>

--- a/src/adhocracy/templates/massmessage/preview.html
+++ b/src/adhocracy/templates/massmessage/preview.html
@@ -23,7 +23,7 @@
     %for r in c.recipients:
       <li>${r.name} &lt;${r.email}&gt;</li>
     %endfor
-    </li>
+    </ul>
 
     %for pkey,pval in c.params.items():
       <input type="hidden" name="${pkey}" value="${pval}" />


### PR DESCRIPTION
Currently, every message has the unsubscription footer. That's fine (even required) in open communities, but out of place if there is some kind of central user management (say, in a company), and if non-technical users may not even be aware we're using adhocracy as a newsletter service.

This PR therefore allows users with global.admin permissions to suppress the footer.
