### PR TITLE
Generate welcome link in user profile

### DIFF
--- a/src/adhocracy/config/routing.py
+++ b/src/adhocracy/config/routing.py
@@ -52,7 +52,8 @@ def make_map(config):
                                          'reset': 'GET',
                                          'activate': 'GET',
                                          'resend': 'GET',
-                                         'set_password': 'POST'},
+                                         'set_password': 'POST',
+                                         'generate_welcome_link': 'POST'},
                  collection={'complete': 'GET',
                              'filter': 'GET'})
 
@@ -71,7 +72,6 @@ def make_map(config):
     map.connect('/message/new', controller='massmessage', action='new')
     map.connect('/message/preview', controller='massmessage', action='preview')
     map.connect('/message/create', controller='massmessage', action='create')
-
 
     map.connect('/register', controller='user', action='new')
     map.connect('/login', controller='user', action='login')

--- a/src/adhocracy/lib/auth/welcome.py
+++ b/src/adhocracy/lib/auth/welcome.py
@@ -12,6 +12,12 @@ from webob.exc import HTTPFound
 from zope.interface import implements
 
 
+def welcome_url(user, code):
+    from adhocracy.lib.helpers import base_url
+    return base_url("/welcome/%s/%s" % (user.user_name, code),
+                    absolute=True)
+
+
 def welcome_enabled(config=pylons.config):
     return asbool(config.get('adhocracy.enable_welcome', 'False'))
 
@@ -36,7 +42,7 @@ class WelcomeRepozeWho(object):
         if not m:
             return None
         u = model.User.find(m.group('id'))
-        if not u or not u.welcome_code or u.password:
+        if not u or not u.welcome_code:
             return None
         if u.welcome_code != m.group('code'):
             return None

--- a/src/adhocracy/static/stylesheets/screen/content.css
+++ b/src/adhocracy/static/stylesheets/screen/content.css
@@ -1864,3 +1864,8 @@ form.password-reset input[type="submit"] {
   padding: 5px 10px;
 }
 
+form.inline-form {
+  background: inherit;
+  padding: 0;
+  display: inline-block;
+}

--- a/src/adhocracy/templates/root.html
+++ b/src/adhocracy/templates/root.html
@@ -36,7 +36,7 @@
       <!-- the external content is loaded inside this tag -->
       <div class="contentWrap"></div>
     </div>
-    %if c.user and c.user.welcome_code and not c.user.password:
+    %if c.user and c.user.welcome_code:
       <form id="user_welcome" action="${h.entity_url(c.user, member='set_password')}" method="post" data-success-message="${_('Password has been set. Have fun!')}">
       ${h.field_token()|n}
       <label><span>${_('Welcome to %s!') % h.site.name()} ${_('Please choose a password:')}</span>

--- a/src/adhocracy/templates/user/tiles.html
+++ b/src/adhocracy/templates/user/tiles.html
@@ -79,6 +79,13 @@
         %if c.user and user != c.user:
             ${components.watch(user)}
         %endif
+
+        %if lib.auth.welcome.can_welcome():
+        <form method="post" class="inline-form" action="${h.entity_url(user, instance=c.instance, member='generate_welcome_link')}">
+        ${h.field_token()|n}
+        <input type="submit" class="button generate_welcome_link" value="${_('Generate welcome link')}" />
+        </form>
+        %endif
     </div>
 
 


### PR DESCRIPTION
Often, an administrator wants to assist a user who forgot their password, or has just been imported in. Add a simple button in the user details, where global administrators can (if welcome is enabled) generate a welcome link for users.
