### PR TITLE
Add an option to use common terms for comments.

### DIFF
--- a/buildouts/hhu.cfg
+++ b/buildouts/hhu.cfg
@@ -76,3 +76,4 @@ settings_override =
     adhocracy.self_deletion_allowed = false
     adhocracy.registration_support_email = normsetzung-support@cs.uni-duesseldorf.de
     adhocracy.hide_individual_votes = true
+    adhocracy.comment_wording = True

--- a/src/adhocracy/lib/event/types.py
+++ b/src/adhocracy/lib/event/types.py
@@ -150,23 +150,23 @@ T_PAGE_DELETE = EventType(
 
 T_COMMENT_CREATE = EventType(
     u"t_comment_create", pri=3,
-    subject=lambda: _(u"New comment: in %(topic)s"),
+    subject=lambda: _(u"New comment: in %(topic)s") if h.comment.wording() else _(u"New argument: in %(topic)s"),
     link_path=lambda e: h.entity_url(e.comment, absolute=True),
-    event_msg=lambda: _(u"commented %(topic)s"),
+    event_msg=lambda: _(u"commented on %(topic)s") if h.comment.wording() else _(u"discussed %(topic)s"),
     text=lambda e: e.rev.text if e.rev else None)
 
 T_COMMENT_EDIT = EventType(
     u"t_comment_edit", pri=3,
-    subject=lambda: _(u"Edited comment: in %(topic)s"),
+    subject=lambda: _(u"Edited comment: in %(topic)s") if h.comment.wording() else _(u"Edited argument: in %(topic)s"),
     link_path=lambda e: h.entity_url(e.comment, absolute=True),
-    event_msg=lambda: _(u"edited comment on %(topic)s"),
+    event_msg=lambda: _(u"edited comment on %(topic)s") if h.comment.wording() else _(u"edited argument about %(topic)s"),
     text=lambda e: e.rev.text if e.rev else None)
 
 T_COMMENT_DELETE = EventType(
     u"t_comment_delete", pri=3,
-    subject=lambda: _(u"Deleted comment: in %(topic)s"),
+    subject=lambda: _(u"Deleted comment: in %(topic)s") if h.comment.wording() else _(u"Deleted argument: in %(topic)s"),
     link_path=lambda e: h.entity_url(e.topic, absolute=True),
-    event_msg=lambda: _(u"deleted comment from %(topic)s"))
+    event_msg=lambda: _(u"deleted comment from %(topic)s") if h.comment.wording() else _(u"deleted argument from %(topic)s"))
 
 T_DELEGATION_CREATE = EventType(
     u"t_delegation_create", pri=2,

--- a/src/adhocracy/lib/helpers/comment_helper.py
+++ b/src/adhocracy/lib/helpers/comment_helper.py
@@ -3,6 +3,8 @@ from adhocracy.lib import cache
 from adhocracy.lib.helpers import proposal_helper as proposal
 from adhocracy.lib.helpers import text_helper as text
 from adhocracy.lib.helpers import url as _url
+from paste.deploy.converters import asbool
+from pylons import config
 
 
 @cache.memoize('comment_url')
@@ -20,3 +22,6 @@ def url(comment, member=None, format=None, comment_page=False, **kwargs):
                     '#c' + str(comment.id))
     return _url.build(comment.topic.instance, 'comment',
                       comment.id, member=member, format=format, **kwargs)
+
+def wording(config=config):
+    return asbool(config.get('adhocracy.comment_wording', False))

--- a/src/adhocracy/templates/comment/ask_delete.html
+++ b/src/adhocracy/templates/comment/ask_delete.html
@@ -1,13 +1,13 @@
 <%inherit file="/template.html" />
 <%namespace name="components" file="/components.html"/>
-<%def name="title()">${_("Comment")}</%def>
+<%def name="title()">${_("Comment") if h.comment.wording() else _("Argument")}</%def>
 
 <%def name="breadcrumbs()">
-    ${h.delegateable.breadcrumbs(c.comment.topic)|n} &raquo; ${_("Comment")}
+    ${h.delegateable.breadcrumbs(c.comment.topic)|n} &raquo; ${_("Comment") if h.comment.wording() else _("Argument")}
 </%def>
 
 <%block name="headline">
-<h1>${_("Comment on %s") % h.delegateable.link(c.comment.topic)|n}</h1>
+<h1>${(_("Comment on %s") if h.comment.wording() else _("Argument about %s")) % h.delegateable.link(c.comment.topic)|n}</h1>
 </%block>
 
 <%block name="main_content">
@@ -18,7 +18,7 @@
     <div class="sidebar">&nbsp;</div>
     <div class="mainbar">
         <div class="warning_box">
-            ${_("Are you sure you want to delete this comment?")|n}
+            ${_("Are you sure you want to delete this comment?") if h.comment.wording() else _("Are you sure you want to delete this argument?")|n}
         </div>
         <center>
             <input type="submit" class="delete" value="${_('Confirm')}" />

--- a/src/adhocracy/templates/comment/edit.html
+++ b/src/adhocracy/templates/comment/edit.html
@@ -1,14 +1,14 @@
 <%inherit file="/template.html" />
 <%namespace name="components" file="/components.html"/>
 <%namespace name="t" file="/comment/tiles.html"/>
-<%def name="title()">${_("Edit comment")}</%def>
+<%def name="title()">${_("Edit comment") if h.comment.wording() else _("Edit argument")}</%def>
 
 <%def name="breadcrumbs()">
-    ${h.delegateable.breadcrumbs(c.comment.topic)|n} &raquo; ${_("Edit comment")}
+    ${h.delegateable.breadcrumbs(c.comment.topic)|n} &raquo; ${_("Edit comment") if h.comment.wording() else _("Edit argument")}
 </%def>
 
 <%block name="headline">
-<h1>${_("Comment on: %s") % h.delegateable.link(c.comment.topic)|n}</h1>
+<h1>${(_("Comment on: %s") if h.comment.wording() else _("Argument about: %s")) % h.delegateable.link(c.comment.topic)|n}</h1>
 </%block>
 
 <%block name="main_content">

--- a/src/adhocracy/templates/comment/history.html
+++ b/src/adhocracy/templates/comment/history.html
@@ -1,9 +1,9 @@
 <%inherit file="/template.html" />
 <%namespace name="components" file="/components.html"/>
-<%def name="title()">${_("Comment History")}</%def>
+<%def name="title()">${_("Comment History") if h.comment.wording() else _("Argument History")}</%def>
 
 <%def name="breadcrumbs()">
-    ${h.delegateable.breadcrumbs(c.comment.topic)|n} &raquo; ${_("Comment History")}
+    ${h.delegateable.breadcrumbs(c.comment.topic)|n} &raquo; ${_("Comment History") if h.comment.wording() else _("Argument History")}
 </%def>
 
 <%block name="headline">

--- a/src/adhocracy/templates/comment/new.html
+++ b/src/adhocracy/templates/comment/new.html
@@ -1,14 +1,14 @@
 <%inherit file="/template.html" />
 <%namespace name="components" file="/components.html"/>
 <%namespace name="t" file="/comment/tiles.html"/>
-<%def name="title()">${_("New comment")}</%def>
+<%def name="title()">${_("New comment") if h.comment.wording() else _("New argument")}</%def>
 
 <%def name="breadcrumbs()">
-    ${h.instance.breadcrumbs(c.instance)|n} &raquo; ${_("New comment")}
+    ${h.instance.breadcrumbs(c.instance)|n} &raquo; ${_("New comment") if h.comment.wording() else _("New argument")}
 </%def>
 
 <%block name="headline">
-<h1>${_("Comment on: %s") % h.delegateable.link(c.topic)|n}</h1>
+<h1>${(_("Comment on: %s") if h.comment.wording() else _("Argument about: %s")) % h.delegateable.link(c.topic)|n}</h1>
 </%block>
 <%block name="main_content">
     ${t.create_form(c.reply, c.topic, wiki=c.wiki, can_wiki=True, variant=c.variant)}

--- a/src/adhocracy/templates/comment/show.html
+++ b/src/adhocracy/templates/comment/show.html
@@ -1,9 +1,9 @@
 <%inherit file="/template.html" />
 <%namespace name="components" file="/components.html"/>
-<%def name="title()">${_("Comment")}</%def>
+<%def name="title()">${_("Comment") if h.comment.wording() else _("Argument")}</%def>
 
 <%def name="breadcrumbs()">
-    ${h.delegateable.breadcrumbs(c.comment.topic)|n} &raquo; ${_("Comment")}
+    ${h.delegateable.breadcrumbs(c.comment.topic)|n} &raquo; ${_("Comment") if h.comment.wording() else _("Argument")}
 </%def>
 
 <%block name="headline">

--- a/src/adhocracy/templates/comment/tiles.html
+++ b/src/adhocracy/templates/comment/tiles.html
@@ -4,7 +4,7 @@
 <%def name="row(tile, comment)">
     <div class="tile">
         <div>
-            <h3><a href="${h.entity_url(comment)}">${_("Comment")}</a> 
+            <h3><a href="${h.entity_url(comment)}">${_("Comment") if h.comment.wording() else _("Argument")}</a> 
                 ${_("on %s") % h.delegateable.link(comment.topic)|n}</h3>
             <div class="meta">
                 ${h.user.link(comment.creator, scope=comment.topic)|n}
@@ -28,7 +28,7 @@
         %if not len(_comments):
             <div class="comment_wrapper">
                 <div class="comment empty">
-                    ${_("No comments were made yet.")}
+                    ${_("No comments were made yet.") if h.comment.wording() else _("No discussions were started yet.")}
                 </div>
             </div>
         %endif
@@ -75,17 +75,18 @@
                href="${h.base_url('/comment/new?topic=%d&amp;wiki=1' % topic.id, topic.instance)}"
                data-target="#${target}"
                id="start-discussion-button">
-                ${_('Start new Discussion')}
+               ${_('Add comment') if h.comment.wording() else _('Start new discussion')}
             </a>
         </div>
         %endif
 
         %elif auth.propose_join():
-        <a class="button add ttip" title="${_('Join instance to comment.')}" rel="#overlay-join-button">${_("Add comment")}</a>
+        <a class="button add ttip" title="${_('Join instance to comment.') if h.comment.wording() else _('Join instance to discuss.')}" rel="#overlay-join-button">${_("Add comment") if h.comment.wording() else _('Add argument')}</a>
+
         %elif auth.propose_login():
-        <a class="button add ttip" title="${_('Login to comment.')}" rel="#overlay-login-button">${_("Add comment")}</a>
+         <a class="button add ttip" title="${_('Login to comment.') if h.comment.wording() else _('Login to discuss.')}" rel="#overlay-login-button">${_("Add comment") if h.comment.wording() else _('Add argument')}</a>
         %elif auth.propose_validate_email():
-        <a class="button add ttip" title="${_('Validate email in order to comment.')}" rel="#overlay-validate-button">${_("Add comment")}</a>
+        <a class="button add ttip" title="${_('Validate email in order to comment.') if h.comment.wording() else _('Validate email in order to discuss.')}" rel="#overlay-validate-button">${_("Add comment") if h.comment.wording() else _("Add argument")}</a>
         %endif
 
     %endif
@@ -120,7 +121,7 @@
         %if not comment.is_deleted():
         ${tile.text|n}
         %else:
-        <span class="hint">${_("This comment has been deleted.")}</span>
+        <span class="hint">${_("This comment has been deleted.") if h.comment.wording() else _("This argument has been deleted.")}</span>
         %endif
 
         %if can.comment.edit(comment):
@@ -148,16 +149,16 @@
                 %if tile.num_children > 0:
                     %if tile.num_children == 1:
                     <a class="show_comments" href="#">
-                        ${_('1 Comment')}
+                        ${_('1 Comment') if h.comment.wording() else _('1 Argument')}
                     </a>
                     %else:
                     <a class="show_comments" href="#">
-                        ${_('%s Comments') % tile.num_children}
+                        ${(_('%s Comments') if h.comment.wording() else _('%s Arguments')) % tile.num_children}
                     </a>
                     %endif
                 %else:
                     <span class="show_comments" href="#">
-                        ${_('%s Comments') % tile.num_children}
+                        ${(_('%s Comments') if h.comment.wording() else _('%s Arguments')) % tile.num_children}
                     </span>
                 %endif
 
@@ -251,7 +252,7 @@ klass_con = klass(-1)
         <div class="c40r">
           <div class="subcr comment_settings">
             <div class="input_wrapper comment_status only-js">
-              ${_(u'Comment is...')}<br />
+              ${_(u'Comment is...') if h.comment.wording() else _(u'Argument is...')}<br />
               <a class="${klass_pro}" 
                  data-status="1" href="#">${_('Pro')}</a>
               <a class="${klass_neutral}" 
@@ -289,7 +290,7 @@ else:
 if wiki is None:
     wiki = c.instance.editable_comments_default
 %>
-  <h4>${_(u'Enter comment text:')}</h4>
+  <h4>${_(u'Enter comment text:') if h.comment.wording() else _(u'Enter argument text:')}</h4>
   <div class="comment_form">
     <form name="new_comment" class="comment_form"
         method="POST" action="${h.base_url('/comment%s' % format, topic.instance)}">
@@ -312,7 +313,7 @@ if wiki is None:
         <div class="c40r">
           <div class="subcr comment_settings">
             <div class="input_wrapper comment_status only-js">
-              ${_(u'Comment is...')}<br />
+              ${_(u'Comment is...') if h.comment.wording() else _(u'Argument is...')}<br />
               <a class="button_small" data-status="1" href="#">${_('Pro')}</a>
               <a class="button_small" data-status="0" href="#">${_('Neutral')}</a>
               <a class="button_small" data-status="-1" href="#">${_('Con')}</a>
@@ -323,7 +324,7 @@ if wiki is None:
               <label>
                   <input id="editable" name="wiki" type="checkbox" 
                          ${'checked="checked"' if wiki else ''}/> 
-                  ${_("Allow others to edit this comment.")}
+                  ${_("Allow others to edit this comment.") if h.comment.wording() else _("Allow others to edit this argument.")}
               </label>
             </div>
             <div class="hr"><hr /></div>
@@ -357,13 +358,14 @@ if wiki is None:
     </div>
 
     <h1 class="page_title">
-        ${_("Discussion on %s") % h.delegateable.link(comment.topic)|n}</h1>
-    
+         ${(_("Comments on %s") if h.comment.wording() else _("Discussion on %s") \
+           ) % h.delegateable.link(comment.topic)|n}</h1>
+
     <div class="panel ${active}">
         <ul class="menu">
             <li><a href="${h.entity_url(comment)}">${_("Context")}</a></li>
             <li><a href="${h.entity_url(comment, comment_page=True)}" 
-                class="discussion">${_("Comment")}</a></li> 
+                class="discussion">${_("Comment") if h.comment.wording() else _("Argument")}</a></li> 
             <li><a href="${h.entity_url(comment, member='history')}" 
                 class="history">${_("History")} (${len(comment.revisions)})</a></li>
             <li><a href="${h.entity_url(comment.poll, member='votes')}" 
@@ -375,7 +377,7 @@ if wiki is None:
 <%def name="form(display=False)">
   <!-- new comment form -->
   <div id="comment_form_template" ${'style="display: none;"' if display == False else ''}>
-    <h4>${_(u'Add comment')}</h4>
+    <h4>${_(u'Add comment') if h.comment.wording() else _(u'Add argument')}</h4>
     <form name="new_comment" class="comment_form" 
         method="POST" action="${h.base_url('/comment')}">
 
@@ -397,7 +399,7 @@ if wiki is None:
         <div class="c40r">
           <div class="subcr comment_settings">
             <div class="input_wrapper comment_status">
-              ${_(u'Comment is...')}<br />
+              ${_(u'Comment is...') if h.comment.wording() else _(u'Argument is...')}<br />
               <a class="button_small" status="pro" href="#">${_('Pro')}</a>
               <a class="button_small" status="neutral" href="#">${_('Neutral')}</a>
               <a class="button_small" status="contra" href="#">${_('Con')}</a>

--- a/src/adhocracy/templates/proposal/show.html
+++ b/src/adhocracy/templates/proposal/show.html
@@ -94,7 +94,9 @@ delegate_url = url if can.delegation.create() else None
                   data-stats-baseurl="${c.monitor_comment_url}"
                   %endif
               >
-                  <h3 id="discussions">${_('Discussions')}</h3>
+              <h3 id="discussions">
+                  ${_('Comments') if h.comment.wording() else _('Discussions')}
+              </h3>
                   ## comments are attached to the description which is a
                   ## :class:`adhocracy.model.Page`
                   ## proposal descriptions have no other variant than head.


### PR DESCRIPTION
If the option adhocracy.comment_wording is set to True, the terms
"comment" and "comments" are used instead of "argument" and
"discussion".

This is necessary to resolve hhucn/adhocracy.hhu_theme#223 without diverging too much from upstream.
