### PR TITLE
Allow custom sender name in massmessages

### DIFF
--- a/src/adhocracy/migration/versions/062_message_sender_name.py
+++ b/src/adhocracy/migration/versions/062_message_sender_name.py
@@ -1,0 +1,9 @@
+from sqlalchemy import MetaData, Table, Unicode, Column
+
+
+def upgrade(migrate_engine):
+    meta = MetaData(bind=migrate_engine)
+
+    table = Table('message', meta, autoload=True)
+    col = Column('sender_name', Unicode(255), nullable=True)
+    col.create(table)

--- a/src/adhocracy/model/message.py
+++ b/src/adhocracy/model/message.py
@@ -22,23 +22,26 @@ message_table = Table(
     Column('creator_id', Integer, ForeignKey('user.id'), nullable=False),
     Column('sender_email', Unicode(255), nullable=False),
     Column('include_footer', Boolean, default=True, nullable=False),
+    Column('sender_name', Unicode(255), nullable=True),
 )
 
 
 class Message(meta.Indexable):
 
-    def __init__(self, subject, body, creator, sender_email,
+    def __init__(self, subject, body, creator, sender_email, sender_name,
                  include_footer=True):
         self.subject = subject
         self.body = body
         self.creator = creator
         self.sender_email = sender_email
+        self.sender_name = sender_name
         self.include_footer = include_footer
 
     @classmethod
-    def create(cls, subject, body, creator, sender_email,
+    def create(cls, subject, body, creator, sender_email, sender_name,
                include_footer=True):
-        message = cls(subject, body, creator, sender_email, include_footer)
+        message = cls(subject, body, creator, sender_email, sender_name,
+                      include_footer)
         meta.Session.add(message)
         meta.Session.flush()
         return message
@@ -84,4 +87,5 @@ class MessageRecipient(object):
                          body,
                          headers={},
                          decorate_body=False,
-                         email_from=self.message.sender_email)
+                         email_from=self.message.sender_email,
+                         name_from=self.message.sender_name)

--- a/src/adhocracy/templates/massmessage/new.html
+++ b/src/adhocracy/templates/massmessage/new.html
@@ -56,13 +56,19 @@
         <div class="input_wrapper">
           %for (key, value) in c.sender_options.iteritems():
           <label>
-            <input type="radio" name="sender" value=${key} ${'checked="checked"' if value['checked'] else '' | n} ${'disabled="disabled"' if not value['enabled'] else '' | n} />${value['email']}
+            <input type="radio" name="sender_email" value=${key} ${'checked="checked"' if value['checked'] else '' | n} ${'disabled="disabled"' if not value['enabled'] else '' | n} />${value['email']}
             %if not value['enabled']:
             <em>${value['reason']}</em>
             %endif
           </label>
           %endfor
         </div>
+
+        %if lib.auth.authorization.has('global.admin'):
+          <label>
+            ${'Customize sender name: '} <input type="text" name="sender_name" />
+          </label>
+        %endif
       </fieldset>
       
       <div class="mainbar">

--- a/src/adhocracy/templates/massmessage/preview.html
+++ b/src/adhocracy/templates/massmessage/preview.html
@@ -12,7 +12,7 @@
     <p>${_("You're about to send the following message to %s recipients:") % c.recipients_count}</p>
 
     <dl>
-      <dt>From:</dt><dd>${c.sender}</dd>
+      <dt>From:</dt><dd>${c.sender_name} &lt;${c.sender_email}&gt;</dd>
       <dt>Subject:</dt><dd>${c.subject}</dd>
     </dl>
     <div class="message_preview_body">${c.body}</div>


### PR DESCRIPTION
The initial impression of an email may not only depend on the sender address, but also the name. We should therefore allow users with global.message privileges to customize the sender name. The functionality is already there, we just need an input field and a database row to store the sender name in.
