### PR TITLE
Warning message if browser is IE7 or older

### DIFF
--- a/src/adhocracy/static/stylesheets/style.css
+++ b/src/adhocracy/static/stylesheets/style.css
@@ -104,9 +104,14 @@ Please define your styles before this section.
 a.ie-message {
   display: block;
   line-height: 40px;
-  font-size: 17px;
+  font-size: 20px;
   font-weight: bold;
   color: white;
   text-align: center;
+  background: red;
+}
+
+a.ie-message:hover {
+  color: white;
   background: red;
 }

--- a/src/adhocracy/templates/root.html
+++ b/src/adhocracy/templates/root.html
@@ -16,7 +16,7 @@
   </head>
 
 <!--[if lte IE 7]>
-      <a href="http://www.browser-update.org/update.html" class="ie-message">${_('Please update your browser (Instructions)!')}</a>
+      <a href="http://www.browser-update.org/update.html" class="ie-message">${_('You are using an outdated web browser (click here to update).')}</a>
 <![endif]-->
 
 <body lang="${c.locale.language}" class="${'logged_in' if c.user else ''}"


### PR DESCRIPTION
If the users browser is less or equal than IE7, a red warning bar will be displayed on top of the screen. It includes a link on how to update your browser (http://www.browser-update.org/update.html).

It looks like this on IE7 (hhu theme):
![ie-message-top](https://f.cloud.github.com/assets/1485226/547690/edc9d100-c2ca-11e2-8e41-b55db917bb40.jpg)
