### PR TITLE
Reduce Shibboleth column length to 255 characters

### DIFF
--- a/src/adhocracy/migration/versions/063_add_shibboleth_table.py
+++ b/src/adhocracy/migration/versions/063_add_shibboleth_table.py
@@ -36,7 +36,7 @@ shibboleth_table = Table(
     Column('create_time', DateTime, default=datetime.utcnow),
     Column('delete_time', DateTime, nullable=True),
     Column('user_id', Integer, ForeignKey('user.id'), nullable=False),
-    Column('persistent_id', Unicode(1024), nullable=False, unique=True,
+    Column('persistent_id', Unicode(255), nullable=False, unique=True,
            index=True),
 )
 

--- a/src/adhocracy/model/shibboleth.py
+++ b/src/adhocracy/model/shibboleth.py
@@ -15,7 +15,7 @@ shibboleth_table = Table(
     Column('create_time', DateTime, default=datetime.utcnow),
     Column('delete_time', DateTime, nullable=True),
     Column('user_id', Integer, ForeignKey('user.id'), nullable=False),
-    Column('persistent_id', Unicode(1024), nullable=False, unique=True,
+    Column('persistent_id', Unicode(255), nullable=False, unique=True,
            index=True),
 )
 


### PR DESCRIPTION
This is required because MySQL doesn't support indexes on tables larger than 767 bytes.
(See http://dev.mysql.com/doc/refman/5.5/en/innodb-restrictions.html for documentation on that).

The current limit of 1024 was arbitrary anyways - according to http://www.switch.ch/aai/support/serviceproviders/persistentid.html , the real limit is 2036 characters.
This change fixes #390.
What we should really do - and this seems to be pondered by Shibboleth protocol designers anyways - is to hash the persistent ID, and to index over that.
If needed, we can still store the original long ID in the database.
