### PR TITLE
Add badge-specific behaviors

### DIFF
--- a/buildouts/hhu.cfg
+++ b/buildouts/hhu.cfg
@@ -80,4 +80,5 @@ settings_override =
     adhocracy.hide_individual_votes = true
     adhocracy.comment_wording = True
     adhocracy.session.implementation = cookie
+    adhocracy.enable_behavior = True
 

--- a/etc/adhocracy.ini.in
+++ b/etc/adhocracy.ini.in
@@ -348,6 +348,8 @@ adhocracy.startpage.proposals.list_length = 0
 # set to false in restrictive environments.
 # adhocracy.autoassign_permissions = true
 
+# Turn on badge-specific UI modifications
+# adhocracy.enable_behavior = True
 
 # Logging configuration
 [loggers]

--- a/src/adhocracy/lib/__init__.py
+++ b/src/adhocracy/lib/__init__.py
@@ -1,3 +1,4 @@
+import behavior
 import democracy
 import text
 import search

--- a/src/adhocracy/lib/behavior.py
+++ b/src/adhocracy/lib/behavior.py
@@ -1,0 +1,28 @@
+""" Change UI depending on user badges """
+
+import collections
+
+from paste.deploy.converters import asbool
+import pylons
+from pylons.i18n import _
+
+
+def behavior_enabled(config=pylons.config):
+    return asbool(config.get('adhocracy.enable_behavior', 'False'))
+
+
+def get_behavior(user, key):
+    assert key in ['proposal_sort_order']
+
+    if not behavior_enabled():
+        return None
+
+    if user is None:
+        return None
+
+    propname = 'behavior_' + key
+    for b in user.badges:
+        v = getattr(b, propname)
+        if v is not None:
+            return v
+    return None

--- a/src/adhocracy/lib/pager.py
+++ b/src/adhocracy/lib/pager.py
@@ -16,6 +16,7 @@ from webob.multidict import MultiDict
 
 from adhocracy import model
 from adhocracy.lib import sorting, tiles
+from adhocracy.lib.behavior import get_behavior
 from adhocracy.lib.helpers import base_url
 from adhocracy.lib.helpers.badge_helper import generate_thumbnail_tag
 from adhocracy.lib.helpers.badge_helper import get_parent_badges
@@ -1459,6 +1460,10 @@ def get_def_proposal_sort_order():
     default_sorting = None
     if c.user and c.user.proposal_sort_order:
         default_sorting = c.user.proposal_sort_order
+    else:
+        bso = get_behavior(c.user, 'proposal_sort_order')
+        if bso:
+            default_sorting = bso
     return default_sorting
 
 

--- a/src/adhocracy/migration/versions/065_badge_behavior_proposal_sort.py
+++ b/src/adhocracy/migration/versions/065_badge_behavior_proposal_sort.py
@@ -1,0 +1,9 @@
+from sqlalchemy import MetaData, Table, Unicode, Column
+
+
+def upgrade(migrate_engine):
+    meta = MetaData(bind=migrate_engine)
+
+    table = Table('badge', meta, autoload=True)
+    col = Column('behavior_proposal_sort_order', Unicode(50), nullable=True)
+    col.create(table)

--- a/src/adhocracy/model/badge.py
+++ b/src/adhocracy/model/badge.py
@@ -37,7 +37,8 @@ badge_table = Table(
     Column('display_group', Boolean, default=False),
     Column('visible', Boolean, default=True),
     # attributes for ThumbnailBadges
-    Column('thumbnail', LargeBinary, default=None, nullable=True)
+    Column('thumbnail', LargeBinary, default=None, nullable=True),
+    Column('behavior_proposal_sort_order',  Unicode(50), nullable=True),
 )
 
 

--- a/src/adhocracy/templates/badge/form.html
+++ b/src/adhocracy/templates/badge/form.html
@@ -125,6 +125,15 @@ ${self.form()}
            value="" />
     %endif
 
+    %if c.badge_type == 'user':
+    %if lib.behavior.behavior_enabled():
+    <h3>Behaviors</h3>
+    <label>${('Default proposal sort order:')}
+        ${components.proposal_sort_order('behavior_proposal_sort_order', c.sorting_orders, include_empty=True)}
+    </label>
+    %endif
+    %endif
+
     <div class="mainbar">
       ${components.savebox(c.base_url, _('Save Badge'))}
     </div>


### PR DESCRIPTION
If the new configuration option adhocracy.enable_behaviors is enabled, user badges can be associated with changes in the UI.
The first UI change is the default sorting order: Instead of defaulting to `mixed`, if the user has a badge with a sorting order behavior attached, she now gets that order.

See hhucn/adhocracy.hhu_theme#121 for details.
