### PR TITLE
tags placeholder

### DIFF
--- a/src/adhocracy/templates/page/new.html
+++ b/src/adhocracy/templates/page/new.html
@@ -61,7 +61,7 @@
 
             <legend>${_("Tag and classify")}</legend>
             <div class="input_wrapper">      
-                <input type="text" name="tags" id="tags" class="long" placeholder="${_('Tags to describe the subject')}" data-instance-baseurl="${h.base_url(append_slash=True)}" />
+                <input type="text" name="tags" id="tags" class="long" placeholder="${_('Tags')}" data-instance-baseurl="${h.base_url(append_slash=True)}" />
             </div>
         </fieldset>
         

--- a/src/adhocracy/templates/proposal/new.html
+++ b/src/adhocracy/templates/proposal/new.html
@@ -105,7 +105,7 @@
       <% h.need.autocomplete %>
       <legend>${_("Tag and classify")}</legend>
       <div class="input_wrapper">      
-        <input type="text" name="tags" id="tags" class="long" placeholder="${_('Tags to describe the subject')}" data-instance-baseurl="${h.base_url(append_slash=True)}" />
+        <input type="text" name="tags" id="tags" class="long" placeholder="${_('Tags')}" data-instance-baseurl="${h.base_url(append_slash=True)}" />
         <p class="info">${_("Multiple tags can be separated by commas.")}</p>
       </div>
         


### PR DESCRIPTION
The input placeholder text for tagging proposals ("Tags to describe the subject" or "Tags um den Inhalt zu beschreiben") are very long and in some cases too long to fit the input element. Therefore I shortened the placeholder text to just "Tags". 

"Tags" is already in the .po files so we do not need to update the translations.
