### PR TITLE
Fix htmlfill when multiple forms are present

### DIFF
--- a/src/adhocracy/controllers/openidauth.py
+++ b/src/adhocracy/controllers/openidauth.py
@@ -116,10 +116,13 @@ class OpenidauthController(BaseController):
             h.flash(message, 'error')
             return redirect(h.entity_url(c.user, member='edit'))
         else:
-            loginhtml = render("/user/login.html")
-            return formencode.htmlfill.render(loginhtml,
+            loginhtml = render("/user/login_tile.html")
+            form = formencode.htmlfill.render(loginhtml,
                                               defaults={'openid': openid},
                                               errors={'openid': message})
+            return render('/user/login.html', {'login_form_code': form})
+
+
 
     def __before__(self):
         self.openid_session = session.get("openid_session", {})

--- a/src/adhocracy/controllers/user.py
+++ b/src/adhocracy/controllers/user.py
@@ -472,9 +472,11 @@ class UserController(BaseController):
             if '_login_value' in request.environ:
                 defaults['login'] = request.environ['_login_value']
             defaults['_tok'] = token_id()
-        return htmlfill.render(render('/user/login.html'),
+        form = render('/user/login_tile.html')
+        form = htmlfill.render(form,
                                errors=errors,
                                defaults=defaults)
+        return render('/user/login.html', {'login_form_code': form})
 
     def perform_login(self):
         pass  # managed by repoze.who

--- a/src/adhocracy/templates/user/login.html
+++ b/src/adhocracy/templates/user/login.html
@@ -6,10 +6,8 @@
 </%block>
 
 <%block name="main_content">
-  <h3>${_("Login")}</h3>
-  %if config.get('adhocracy.login_style', 'default') == 'alternate':
-      <%include file="/user/login_form_alternate.html"/>
-  %else:
-      <%include file="/user/login_form.html"/>
-  %endif
+## The actual form is in login_tile.html, since it has to be handled by
+## htmlfill before pasting in here in order to allow multiple login forms
+## on a single page.
+${c.login_form_code|n}
 </%block>

--- a/src/adhocracy/templates/user/login_tile.html
+++ b/src/adhocracy/templates/user/login_tile.html
@@ -1,0 +1,6 @@
+<h3>${_("Login")}</h3>
+%if config.get('adhocracy.login_style', 'default') == 'alternate':
+  <%include file="/user/login_form_alternate.html"/>
+%else:
+  <%include file="/user/login_form.html"/>
+%endif


### PR DESCRIPTION
Currently, htmlfilll always picks the first form it can find in the HTML code, and that is usually the inline form.
Instead, we should render just the login tile, pass it to htmlfill, and then paste it into the rest of the template.
Fixes #423.
