### PR TITLE
Allow adhocracy.registration_support_email as from.

### DIFF
--- a/src/adhocracy/controllers/massmessage.py
+++ b/src/adhocracy/controllers/massmessage.py
@@ -129,7 +129,7 @@ class MassmessageController(BaseController):
                 'email': config.get('adhocracy.registration_support_email'),
                 'checked': False,
                 'enabled': config.get('adhocracy.registration_support_email') is not None,
-                'reason': _("adhocracy.support_email not set"),
+                'reason': _("adhocracy.registration_support_email not set"),
             }
         }
 


### PR DESCRIPTION
When using different email adresses for registration and general
support, for some mass messages it is more appropriate to use the
registration support address. Specifically, invitations.
Fixes hhucn/adhocracy.hhu_theme#353.
