### PR TITLE
Do not cache poll widget if user is logged in.

### DIFF
--- a/src/adhocracy/lib/tiles/comment_tiles.py
+++ b/src/adhocracy/lib/tiles/comment_tiles.py
@@ -60,7 +60,7 @@ def header(comment, tile=None, active='comment'):
 
 def list(topic, root=None, comments=None, variant=None, recurse=True,
          ret_url=''):
-    cached = True if c.user is None else False
+    cached = c.user is None
     if comments is None:
         comments = topic.comments
     return render_tile('/comment/tiles.html', 'list', tile=None,
@@ -70,8 +70,9 @@ def list(topic, root=None, comments=None, variant=None, recurse=True,
 
 
 def show(comment, recurse=True, ret_url=''):
+    cached = c.user is None
     can_edit = can.comment.edit(comment)
     groups = sorted(c.user.groups if c.user else [])
     return render_tile('/comment/tiles.html', 'show', CommentTile(comment),
-                       comment=comment, cached=True, can_edit=can_edit,
+                       comment=comment, cached=cached, can_edit=can_edit,
                        groups=groups, ret_url=ret_url, recurse=recurse)

--- a/src/adhocracy/lib/tiles/poll_tiles.py
+++ b/src/adhocracy/lib/tiles/poll_tiles.py
@@ -209,11 +209,12 @@ def widget(poll, cls='', deactivated=False, delegate_url=None):
         An URL if a delegate button should be shown beside the vote
         widget. If *None* (default) no button will be shown.
     '''
+    cached = c.user is None
     t = PollTile(poll, deactivated, widget_class=cls)
     return render_tile('/poll/tiles.html', 'widget',
                        t, poll=poll, user=c.user, widget_class=cls,
                        delegate_url=delegate_url, deactivated=deactivated,
-                       cached=True)
+                       cached=cached)
 
 
 def header(poll, active=''):


### PR DESCRIPTION
The poll widget used other tiles which were cached, resulting in wrong
CSRF tokens. Deactivate caching for these tiles if a user is logged in.
