### PR TITLE
no shadow for form_wrappers in overlays

### DIFF
--- a/src/adhocracy/static_src/stylesheets/components/_forms.scss
+++ b/src/adhocracy/static_src/stylesheets/components/_forms.scss
@@ -1,6 +1,11 @@
 .form_wrapper {
     background: url("/images/shadow_image_large.jpg") no-repeat scroll center bottom transparent;
     padding-bottom: 18px;
+
+    .overlay & {
+        background: none;
+        padding-bottom: 0;
+    }
 }
 
 .form_wrapper form, #searchbox form {


### PR DESCRIPTION
In the default theme forms have a shadow. This is done using a background image. This works fine for forms in  the main content but is to wide for overlays. So I added a css rule to hide the shadow in overlays.
