### PR TITLE
Fix poll caching (fixes hhucn/adhocracy.hhu_theme#391)

### DIFF
--- a/src/adhocracy/lib/tiles/comment_tiles.py
+++ b/src/adhocracy/lib/tiles/comment_tiles.py
@@ -1,3 +1,4 @@
+from pylons import session
 from pylons import tmpl_context as c
 
 from adhocracy.lib import text
@@ -74,4 +75,5 @@ def show(comment, recurse=True, ret_url=''):
     groups = sorted(c.user.groups if c.user else [])
     return render_tile('/comment/tiles.html', 'show', CommentTile(comment),
                        comment=comment, cached=True, can_edit=can_edit,
-                       groups=groups, ret_url=ret_url, recurse=recurse)
+                       groups=groups, ret_url=ret_url, recurse=recurse,
+                       cache_session=session.id)

--- a/src/adhocracy/lib/tiles/poll_tiles.py
+++ b/src/adhocracy/lib/tiles/poll_tiles.py
@@ -1,4 +1,5 @@
 from pylons import tmpl_context as c
+from pylons import session
 from pylons.i18n import _
 
 from adhocracy import model
@@ -213,7 +214,7 @@ def widget(poll, cls='', deactivated=False, delegate_url=None):
     return render_tile('/poll/tiles.html', 'widget',
                        t, poll=poll, user=c.user, widget_class=cls,
                        delegate_url=delegate_url, deactivated=deactivated,
-                       cached=True)
+                       cached=True, cache_session=session.id)
 
 
 def header(poll, active=''):


### PR DESCRIPTION
Add session id to the cache key of poll and comment tiles.

This remedies CSRF alerts and thus broken poll widget, if a user
revisits cached tiles with a different session, e.g. by using a
different browser or logging out and in again.
