### PR TITLE
Permanently save "disable all tutorials" setting (fixes #109)

### DIFF
--- a/src/adhocracy/controllers/root.py
+++ b/src/adhocracy/controllers/root.py
@@ -100,8 +100,8 @@ class RootController(BaseController):
         if 'disable' in request.params:
             name = request.params.get('disable')
             if name == 'ALL':
-                h.tutorial.disable(None)
+                h.tutorial.disable(None, c.user)
             else:
-                h.tutorial.disable(name)
+                h.tutorial.disable(name, c.user)
         else:
             h.tutorial.enable()

--- a/src/adhocracy/lib/helpers/tutorial.py
+++ b/src/adhocracy/lib/helpers/tutorial.py
@@ -2,14 +2,18 @@ from paste.deploy.converters import asbool
 from pylons import config
 from pylons import session
 
+from adhocracy.model import meta
+
 ALLKEY = 'disable_tutorials'
 ONEKEY = 'disable_tutorial_%s'
 
 
-def show(name):
+def show(name, user):
     if not asbool(config.get('adhocracy.show_tutorials', 'true')):
         return False
 
+    if user is not None and user.no_help:
+        return False
     if session.get(ALLKEY, False):
         return False
     elif session.get(ONEKEY % name):
@@ -18,9 +22,13 @@ def show(name):
         return True
 
 
-def disable(name):
+def disable(name, user):
     if name is None:
-        session[ALLKEY] = True
+        if user is None:
+            session[ALLKEY] = True
+        else:
+            user.no_help = True
+            meta.Session.commit()
     else:
         session[ONEKEY % name] = True
     session.save()

--- a/src/adhocracy/templates/components.html
+++ b/src/adhocracy/templates/components.html
@@ -279,7 +279,7 @@ $(document).ready(function () {
 
 <%def name="tutorial()">
 
-%if h.tutorial.show(c.tutorial):
+%if h.tutorial.show(c.tutorial, c.user):
 
 <% h.need.joyride %>
 

--- a/src/adhocracy/templates/root.html
+++ b/src/adhocracy/templates/root.html
@@ -200,7 +200,7 @@
           <%block name="flashmessages"></%block>
           <%block name="infoboxes"></%block>
 
-          %if c.tutorial and h.tutorial.show(c.tutorial):
+          %if c.tutorial and h.tutorial.show(c.tutorial, c.user):
           <div class="only-js" id="tutorial-banner">
               <%components:build_infobox>
               <div id="tutorial-intro">


### PR DESCRIPTION
This now uses the `no_help` user attribute for this purpose.

Note that disabling of single tutorials is still only stored in a
session cookie.
