### PR TITLE
Do not allow voting in frozen instances

### DIFF
--- a/src/adhocracy/lib/auth/poll.py
+++ b/src/adhocracy/lib/auth/poll.py
@@ -1,5 +1,5 @@
 from paste.deploy.converters import asbool
-from pylons import config
+from pylons import config, tmpl_context as c
 import user
 
 
@@ -34,6 +34,7 @@ def delete(check, p):
 def vote(check, p):
     check.valid_email()
     check.other('poll_has_ended', p.has_ended())
+    check.other('instance_frozen', c.instance.frozen)
 
     check.other('select_poll_not_mutable',
                 (p.action == p.SELECT and p.selection and


### PR DESCRIPTION
Currently, users can still vote in an instance that has been marked as frozen. Since voting can have significant changes on the appraisal of the content, it should not be allowed in frozen instances.
Fixes hhucn/adhocracy.hhu_theme#422

This just copies the check from `auth/proposal.py` to `auth/poll.py`.
