### PR TITLE
install required version of setuptools

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -154,7 +154,7 @@ fi
 if ! $not_use_sudo_commands; then
     case $distro in
         debian )
-    PKGS_TO_INSTALL=$PKGS_TO_INSTALL' gcc make build-essential bin86 unzip libpcre3-dev git mercurial python python-setuptools libssl-dev libbz2-dev pkg-config libsqlite3-dev openjdk-6-jre libpq-dev'
+    PKGS_TO_INSTALL=$PKGS_TO_INSTALL' gcc make build-essential bin86 unzip libpcre3-dev git mercurial python libssl-dev libbz2-dev pkg-config libsqlite3-dev openjdk-6-jre libpq-dev'
     PKGS_TO_INSTALL=$PKGS_TO_INSTALL' openssh-client mutt'
     PKGS_TO_INSTALL=$PKGS_TO_INSTALL' ruby rubygems'
 
@@ -289,6 +289,13 @@ fi
 
 # Set up adhocracy configuration
 ln -s -f "${buildout_cfg_file}" ./buildout_current.cfg
+
+case $distro in
+    debian )
+echo "installing setuptools with easy_install"
+python/python-2.7/bin/pip install "distribute>=0.7"
+;;
+esac
 
 # bootstrap our buildout if it is outdated or not available
 HAVE_BUILDOUT_VERSION=$(bin/buildout --version 2>&1 | cut -d ' ' -f 3)


### PR DESCRIPTION
Fixes https://github.com/liqd/adhocracy/issues/479 :
`bin/python bootstrap.py throws: "pkg_resources.DistributionNotFound: setuptools>=0.7"`
