### PR TITLE
load footer columns from staticpages if present

### DIFF
--- a/src/adhocracy/lib/helpers/staticpage_helper.py
+++ b/src/adhocracy/lib/helpers/staticpage_helper.py
@@ -24,3 +24,12 @@ def get_body(key, default=''):
     if res is None:
         return default
     return res.body
+
+
+def render_footer_column(column):
+    path = u'footer_' + unicode(column)
+    page = staticpage.get_static_page(path)
+    if page is None:
+        return None
+    else:
+        return page.body

--- a/src/adhocracy/templates/footer.html
+++ b/src/adhocracy/templates/footer.html
@@ -4,7 +4,9 @@
         <div class="page_wrapper">
           <div id="footer_line">
             <div id="second_footer_line" class="subcolumns" role="complementary">
-              <div class="c33l footer_content">
+              <div class="c33l footer_content" id="footer_1">
+                <% footer_1 = h.staticpage.render_footer_column(1) %>
+                %if footer_1 is None:
                   <ul>
                       <li><a class="staticlink_about" 
                              href="/static/about.html">
@@ -19,9 +21,14 @@
                           ${_("terms and conditions")}
                       </a></li>
                   </ul>
+                %else:
+                ${footer_1|n}
+                %endif
               </div>
 
-              <div class="c33l footer_content">
+              <div class="c33l footer_content" id="footer_2">
+                <% footer_2 = h.staticpage.render_footer_column(2) %>
+                %if footer_2 is None:
                   <ul>
                       <li><a class="staticlink_privacy" 
                              href="/static/privacy.html">
@@ -32,9 +39,14 @@
                           ${_("imprint")}
                       </a></li>
                   </ul>
+                %else:
+                ${footer_2|n}
+                %endif
               </div>
 
-              <div class="c33r footer_content">
+              <div class="c33r footer_content" id="footer_3">
+                <% footer_3 = h.staticpage.render_footer_column(3) %>
+                %if footer_3 is None:
                 <div class="subcr">
                   <div class="footer_box">
                     <div class="subcolumns">
@@ -48,6 +60,9 @@
                     </div>
                   </div>
                 </div>
+                %else:
+                ${footer_3|n}
+                %endif
               </div>
 
             </div>


### PR DESCRIPTION
The default footer is (in most parts) translatable. However for many of our projects we want to customize the footer. We usually do that using diazo. While this allows us to customize we loose translation.

This PR allows to define footer columns in staticpages. This way we get translation and customization at the same time. If a footer column does not exist this falls back to the original template.

To use this remove the relevant rules from `rules.xml` and create `footer_1`, `footer_2` and `footer_3` in your staticpage backend (e.g. kotti).
