### PR TITLE
fix long subnav

### DIFF
--- a/src/adhocracy/static_src/stylesheets/components/_forms.scss
+++ b/src/adhocracy/static_src/stylesheets/components/_forms.scss
@@ -90,7 +90,7 @@ form .error {
 /* searchform */
 #searchbox,
 .list_filter {
-    display: block;
+    float: right;
     overflow: hidden;
     padding-top: 19px;
     padding-right: 20px;

--- a/src/adhocracy/static_src/stylesheets/widgets/_subheader.scss
+++ b/src/adhocracy/static_src/stylesheets/widgets/_subheader.scss
@@ -4,7 +4,6 @@
     overflow: hidden;
     padding-top: 27px;
     margin-bottom: 40px;
-    max-height: 100px;
     overflow: hidden;
 }
 

--- a/src/adhocracy/templates/navigation.html
+++ b/src/adhocracy/templates/navigation.html
@@ -119,8 +119,6 @@
   <div id="subheader" class="${'logo' if logo else ''}">
     <div class="page_margins">
       <div class="page_wrapper">
-        <!-- begin: sub navi -->
-        
         <div id="logo_row">
             <div id="organisation_logo">
                 %if url:
@@ -141,16 +139,6 @@
             %endif
         </div>
 
-        <!-- begin: sub navi -->
-        <nav>
-          <div class="hlist">
-            <ul id="subnav">
-
-                ${caller.body()}
-
-            </ul>
-          </div>
-        </nav>
         %if search_action:
         <div id="searchbox">
           <form action="${search_action}" 
@@ -161,6 +149,17 @@
           </form>
         </div>
         %endif
+
+        <!-- begin: sub navi -->
+        <nav>
+          <div class="hlist">
+            <ul id="subnav">
+
+                ${caller.body()}
+
+            </ul>
+          </div>
+        </nav>
       </div>
     </div>
   </div>


### PR DESCRIPTION
When many optional features are activated (norms, maps, ...) the subnav might get to large to fit besides the searchbox. In that case the searchbox is displayed below the subnav. As many themes (including the default) display the subnav as tabs this looks broken.

This fixes that by simply switching subnav and searchbox in the template. 

![subnav_broken](https://f.cloud.github.com/assets/202576/1027048/b303937c-0e69-11e3-8361-ab042ef526b6.png)

![subnav_fixed](https://f.cloud.github.com/assets/202576/1027050/b51f1410-0e69-11e3-94f5-9d10d95ad86f.png)
