### PR TITLE
Allow came_from in welcome URLs

### DIFF
--- a/src/adhocracy/controllers/user.py
+++ b/src/adhocracy/controllers/user.py
@@ -1261,9 +1261,12 @@ class UserController(BaseController):
 
     def welcome(self, id, token):
         # Intercepted by WelcomeRepozeWho, only errors go in here
+        if c.user:
+            return redirect(request.params.get('came_from', '/'))
+
         h.flash(_('You already have a password - use that to log in.'),
                 'error')
-        return redirect(h.base_url('/login'))
+        return redirect(h.base_url('/login', query_params=request.params))
 
     @RequireInternalRequest(methods=['POST'])
     @guard.perm('global.admin')

--- a/src/adhocracy/lib/auth/welcome.py
+++ b/src/adhocracy/lib/auth/welcome.py
@@ -1,5 +1,6 @@
 """ Automatically log in an invited user """
 
+import urlparse
 import re
 
 import adhocracy.model as model
@@ -62,9 +63,14 @@ class WelcomeRepozeWho(object):
         if not is_correct:
             return None
 
-        from adhocracy.lib.helpers import base_url
-        root_url = base_url('/', instance=None, config=self.config)
-        environ['repoze.who.application'] = HTTPFound(location=root_url)
+        qs = urlparse.parse_qs(environ['QUERY_STRING'])
+        if 'came_from' in qs:
+            redirect_url = qs['came_from'][0]
+
+        if not redirect_url:
+            from adhocracy.lib.helpers import base_url
+            redirect_url = base_url('/', instance=None, config=self.config)
+        environ['repoze.who.application'] = HTTPFound(location=redirect_url)
 
         return {
             'repoze.who.plugins.welcome.userid': u.user_name,


### PR DESCRIPTION
Sometimes, we want to redirect users to a specific page after logging them in via welcome.

Fixes hhucn/adhocracy.hhu_theme#430 .
