### PR TITLE
use compass environment (fixes #509)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ etc/sysv-init
 etc/adhocracy-interactive.ini
 etc/test.ini
 etc/compass.rb
+etc/compass.min.rb
 mailsink
 adhocracy-test-chroot
 RELEASE-VERSION

--- a/buildouts/stylesheets.cfg
+++ b/buildouts/stylesheets.cfg
@@ -6,6 +6,7 @@
 parts +=
     rubygems
     compass
+    compass.min
     stylesheets
 
 [rubygems]
@@ -20,8 +21,15 @@ input = ${buildout:directory}/etc/compass.rb.in
 output = ${buildout:directory}/etc/compass.rb
 mode = 755
 
+[compass.min]
+recipe = collective.recipe.template
+input = ${buildout:directory}/etc/compass.min.rb.in
+output = ${buildout:directory}/etc/compass.min.rb
+mode = 755
+
 [stylesheets]
 recipe = plone.recipe.command
 command =
     ${buildout:bin-directory}/compass compile --force -c ${buildout:directory}/etc/compass.rb
+    ${buildout:bin-directory}/compass compile --force -c ${buildout:directory}/etc/compass.min.rb
 update-command = ${stylesheets:command}

--- a/etc/compass.min.rb.in
+++ b/etc/compass.min.rb.in
@@ -1,0 +1,10 @@
+# To change this config file please edit *:in and rerun buildout:
+
+http_path = "/"
+css_dir = "src/adhocracy/static/stylesheets/min"
+sass_dir = "${adhocracy_code:relative_theme_dir}/static_src/stylesheets"
+images_dir = "${adhocracy_code:relative_theme_dir}/static/images"
+javascripts_dir = "${adhocracy_code:relative_theme_dir}/static/javascripts"
+environment = :production
+
+add_import_path "src/adhocracy/static_src/stylesheets"

--- a/src/adhocracy/static/__init__.py
+++ b/src/adhocracy/static/__init__.py
@@ -17,7 +17,8 @@ bootstrap = Group([bootstrap_js])
 # --[ stylesheets ]---------------------------------------------------------
 
 stylesheets_library = Library('stylesheets', 'stylesheets')
-style = Resource(stylesheets_library, 'adhocracy.css')
+style = Resource(stylesheets_library, 'adhocracy.css',
+                 minified='min/adhocracy.css')
 stylesheets = Group([style])
 
 


### PR DESCRIPTION
This makes use of the compass `environment` setting. That way we get minified css in production and debugging information in development.

For some reason it is very hard to produce multiple files from the same sources with compass so the solution is not as elegant as I would wish.
