### PR TITLE
Allow to freeze single proposals (fixes #559)

### DIFF
--- a/src/adhocracy/controllers/delegation.py
+++ b/src/adhocracy/controllers/delegation.py
@@ -48,19 +48,19 @@ class DelegationController(BaseController):
             return self.not_implemented(format=format)
 
     @RequireInstance
-    @guard.delegation.create()
     @validate(schema=DelegationNewForm(), form="bad_request",
               post_only=False, on_get=True)
     def new(self):
         c.scope = self.form_result.get('scope')
+        require.delegation.create(c.scope)
         return render("/delegation/new.html")
 
     @RequireInstance
     @csrf.RequireInternalRequest(methods=["POST"])
-    @guard.delegation.create()
     @validate(schema=DelegationCreateForm(), form="new", post_only=True)
     def create(self, format='html'):
         c.scope = self.form_result.get('scope')
+        require.delegation.create(c.scope)
         agents = filter(lambda f: f is not None, self.form_result.get('agent'))
         if not len(agents) or agents[0] == c.user:
             h.flash(_("Invalid delegation recipient"), 'error')

--- a/src/adhocracy/controllers/proposal.py
+++ b/src/adhocracy/controllers/proposal.py
@@ -60,6 +60,8 @@ class ProposalUpdateForm(ProposalEditForm):
     text = validators.String(max=20000, min=4, not_empty=True)
     wiki = validators.StringBool(not_empty=False, if_empty=False,
                                  if_missing=False)
+    frozen = validators.StringBool(not_empty=False, if_empty=False,
+                                   if_missing=False)
     milestone = forms.MaybeMilestone(if_empty=None,
                                      if_missing=None)
     category = formencode.foreach.ForEach(forms.ValidCategoryBadge())
@@ -252,6 +254,7 @@ class ProposalController(BaseController):
         if not defaults:
             # Just clicked on edit
             defaults['watch'] = h.find_watch(c.proposal) is not None
+            defaults['frozen'] = c.proposal.frozen
         defaults.update({"category": c.category.id if c.category else None})
         return htmlfill.render(render("/proposal/edit.html"),
                                defaults=defaults,
@@ -286,6 +289,10 @@ class ProposalController(BaseController):
             wiki = self.form_result.get('wiki')
         else:
             wiki = c.proposal.description.head.wiki
+
+        if h.has_permission('proposal.freeze'):
+            c.proposal.frozen = self.form_result.get('frozen')
+
         _text = model.Text.create(c.proposal.description, model.Text.HEAD,
                                   c.user,
                                   self.form_result.get('label'),

--- a/src/adhocracy/lib/auth/comment.py
+++ b/src/adhocracy/lib/auth/comment.py
@@ -30,7 +30,8 @@ def create_on(check, topic):
     check.valid_email()
     if has('instance.admin'):
         return
-    check.other('topic_instance_frozen', topic.instance.frozen)
+    check.other('comment_topic_frozen', topic.is_frozen())
+    check.other('comment_topic_instance_frozen', topic.instance.frozen)
     create(check)
 
 
@@ -42,9 +43,9 @@ def reply(check, parent):
 
 def edit(check, co):
     check.valid_email()
-    check.other('comment_not_mutable', not co.is_mutable())
     if has('instance.admin'):
         return
+    check.other('comment_not_mutable', not co.is_mutable())
     check.other('comment_topic_instance_frozen', co.topic.instance.frozen)
     check.perm('comment.edit')
     show(check, co)
@@ -69,6 +70,7 @@ def delete(check, co):
 
 def rate(check, co):
     check.valid_email()
+    check.other('comment_topic_frozen', co.topic.is_frozen())
     check.other('comment_topic_instance_frozen', co.topic.instance.frozen)
     show(check, co)
     check.other('comment_poll_is_none', co.poll is not None)

--- a/src/adhocracy/lib/auth/delegation.py
+++ b/src/adhocracy/lib/auth/delegation.py
@@ -14,15 +14,18 @@ def show(check, d):
     check.other('no_instance_allow_delegate', not c.instance.allow_delegate)
 
 
-def create(check):
+def create(check, scope=None):
     check.valid_email()
     check.perm('delegation.create')
     user.vote(check)
     check.other('no_instance_allow_delegate', not c.instance.allow_delegate)
+    if scope is not None:
+        check.other('scope_frozen', scope.is_frozen())
 
 
 def edit(check, d):
     check.valid_email()
+    check.other('scope_frozen', d.scope.is_frozen())
     check.other('cannot_edit_delegations', True)
 
 
@@ -33,3 +36,4 @@ def delete(check, d):
     check.other('no_instance_allow_delegate', not c.instance.allow_delegate)
     check.other(NOT_LOGGED_IN, not c.user)
     check.other('delegation_principal_is_not_user', d.principal != c.user)
+    check.other('scope_frozen', d.scope.is_frozen())

--- a/src/adhocracy/lib/auth/poll.py
+++ b/src/adhocracy/lib/auth/poll.py
@@ -34,6 +34,7 @@ def delete(check, p):
 def vote(check, p):
     check.valid_email()
     check.other('poll_has_ended', p.has_ended())
+    check.other('scope_frozen', p.scope.is_frozen())
     check.other('instance_frozen', c.instance.frozen)
 
     check.other('select_poll_not_mutable',

--- a/src/adhocracy/lib/auth/proposal.py
+++ b/src/adhocracy/lib/auth/proposal.py
@@ -47,6 +47,8 @@ def edit(check, p):
 
 def delete(check, p):
     check.valid_email()
+    if has('instance.admin'):
+        return
     check.perm('proposal.delete')
     show(check, p)
     check.other('proposal_not_mutable', not p.is_mutable())
@@ -54,6 +56,7 @@ def delete(check, p):
 
 def rate(check, p):
     check.valid_email()
+    check.other('proposal_frozen', p.frozen)
     check.other('instance_frozen', c.instance.frozen)
     show(check, p)
     if p.rate_poll is None:

--- a/src/adhocracy/lib/auth/selection.py
+++ b/src/adhocracy/lib/auth/selection.py
@@ -23,6 +23,8 @@ def create(check, p):
 def edit(check, s):
     check.valid_email()
     check.other('selections_can_not_be_edited', False)
+    check.other('proposal_not_mutable',
+                s.proposal and not s.proposal.is_mutable())
 
 
 def delete(check, s):

--- a/src/adhocracy/lib/install.py
+++ b/src/adhocracy/lib/install.py
@@ -116,6 +116,7 @@ def setup_entities(config, initial_setup):
         u'proposal.create': advisor,
         u'proposal.delete': moderator,
         u'proposal.edit': advisor,
+        u'proposal.freeze': supervisor,
         u'proposal.show': anonymous,
         u'proposal.view': anonymous,
         u'static.show': anonymous,

--- a/src/adhocracy/migration/versions/072_add_delegateable_frozen.py
+++ b/src/adhocracy/migration/versions/072_add_delegateable_frozen.py
@@ -1,0 +1,10 @@
+from sqlalchemy import MetaData, Table, Column
+from sqlalchemy import Boolean
+
+
+def upgrade(migrate_engine):
+    meta = MetaData(bind=migrate_engine)
+
+    table = Table('delegateable', meta, autoload=True)
+    col = Column('frozen', Boolean, default=0)
+    col.create(table)

--- a/src/adhocracy/model/comment.py
+++ b/src/adhocracy/model/comment.py
@@ -135,7 +135,10 @@ class Comment(meta.Indexable):
         return self.latest.create_time != self.create_time
 
     def is_mutable(self):
-        return True  # self.topic.is_mutable()
+        return self.topic.is_mutable()
+
+    def is_frozen(self):
+        return self.topic.is_frozen()
 
     def _index_id(self):
         return self.id

--- a/src/adhocracy/model/delegateable.py
+++ b/src/adhocracy/model/delegateable.py
@@ -11,7 +11,7 @@ from datetime import datetime
 import logging
 
 from sqlalchemy import Table, Column, ForeignKey, or_
-from sqlalchemy import DateTime, Integer, String, Unicode
+from sqlalchemy import Boolean, DateTime, Integer, String, Unicode
 
 import meta
 import instance_filter as ifilter
@@ -38,7 +38,8 @@ delegateable_table = Table(
     Column('delete_time', DateTime, nullable=True),
     Column('milestone_id', Integer, ForeignKey('milestone.id'), nullable=True),
     Column('creator_id', Integer, ForeignKey('user.id'), nullable=False),
-    Column('instance_id', Integer, ForeignKey('instance.id'), nullable=False)
+    Column('instance_id', Integer, ForeignKey('instance.id'), nullable=False),
+    Column('frozen', Boolean, default=False),
 )
 
 

--- a/src/adhocracy/model/page.py
+++ b/src/adhocracy/model/page.py
@@ -306,6 +306,12 @@ class Page(Delegateable):
             return self.proposal.is_mutable()
         return not self.instance.frozen
 
+    def is_frozen(self):
+        if self.function == self.DESCRIPTION and self.proposal:
+            return self.proposal.frozen
+        else:
+            return self.frozen
+
     def user_position(self, user):
         if self.function == self.DESCRIPTION and self.proposal:
             return self.proposal.user_position(user)

--- a/src/adhocracy/model/proposal.py
+++ b/src/adhocracy/model/proposal.py
@@ -52,7 +52,10 @@ class Proposal(Delegateable):
 
     def is_mutable(self):
         return (not self.is_adopt_polling()) and (not self.adopted) and \
-            (not self.instance.frozen)
+            (not self.frozen) and (not self.instance.frozen)
+
+    def is_frozen(self):
+        return self.frozen
 
     def has_implementation(self):
         from text import Text

--- a/src/adhocracy/templates/poll/tiles.html
+++ b/src/adhocracy/templates/poll/tiles.html
@@ -20,7 +20,7 @@ con = tile.widget_action_attrs(model.Vote.NO)
         <span class="vote_count ${tile.count_class}"
           >${tile.display_score}</span
     %endif
-    %if tile.can_vote or tile.can_show:
+    %if tile.can_vote:
     ><a href="${pro['url']}"
         class="${pro['class']} ttip ${'do_vote' if tile.can_vote else ''}"
         title="${pro['title']}"

--- a/src/adhocracy/templates/proposal/edit.html
+++ b/src/adhocracy/templates/proposal/edit.html
@@ -1,6 +1,7 @@
 <%inherit file="/template.html" />
 <%namespace name="tiles_html" file="/proposal/tiles.html"/>
 <%namespace name="components" file="/components.html"/>
+<%namespace name="forms" file="/forms.html"/>
 <%def name="title()">${_("Edit %s") % c.proposal.title}</%def>
 
 <%def name="breadcrumbs()">
@@ -51,6 +52,10 @@
         <input type="checkbox" ${'checked="checked"' if c.proposal.description.head.wiki == 1 else ''} name="wiki" id="wiki" value="1" />
         ${_("Allow others to edit this proposal.")}</label>
       </div>
+      %endif
+
+      %if h.has_permission('proposal.freeze'):
+      ${forms.checkbox(_(u"Freeze proposal"), 'frozen')}
       %endif
 
       <div class="input_wrapper">

--- a/src/adhocracy/templates/proposal/show.html
+++ b/src/adhocracy/templates/proposal/show.html
@@ -32,9 +32,9 @@
 
 
 <%block name="main_content">
-<% 
+<%
 url = h.base_url('/delegation/new?scope=%s' % str(c.proposal.id))
-delegate_url = url if can.delegation.create() else None
+delegate_url = url if can.delegation.create(c.proposal) else None
 %>
 
     %if not c.proposal.is_adopt_polling() and c.proposal.rate_poll:


### PR DESCRIPTION
This allows to mark proposals as frozen for users with a newly
introduced `proposal.freeze` permission, which is by default assigned to
instance admins.

If a proposal is frozen, it isn't possible
- to edit the proposal (apart from instance admins),
- to comment the proposal (apart from instance admins),
- to rate / to delegate the proposal.

It's also not possible to rate selections, while it is still possible to
edit selections and to comment on selections. These restrictions will be
implemented after merging the sectionpages branch.
