### PR TITLE
don't allow headings in user generated content to be as big as our own

### DIFF
--- a/src/adhocracy/static_src/stylesheets/components/_type.scss
+++ b/src/adhocracy/static_src/stylesheets/components/_type.scss
@@ -20,6 +20,22 @@ h4, legend { font-size: 20px; margin-bottom: 10px; font-weight: normal; }
 h5 { font-size: 16px; margin-bottom: 5px; font-weight: normal; }
 h6 { font-size: 14px; font-weight: normal; color: $fg1; }
 
+/* don't allow headings in user generated content to be as big
+ * as our own */
+.comment .body,
+.proposal .body {
+    h1, h2, h3, h4, h5, h6 {
+        font-size: 1em;
+        margin: 10px 0;
+    }
+    h1 {
+        font-size: 1.2em;
+    }
+    h2 {
+        font-size: 1.1em;
+    }
+}
+
 p {
     margin-bottom: 20px;
     word-wrap: break-word;

--- a/src/adhocracy/templates/proposal/show.html
+++ b/src/adhocracy/templates/proposal/show.html
@@ -46,7 +46,7 @@ ${tiles.poll.widget(c.proposal.adopt_poll, cls='big', delegate_url=delegate_url)
 %endif
 
 <section>
-    <article>
+    <article class="proposal">
         <h2>
             ${h.delegateable.link(c.proposal, link=False)|n}
             <div class="utility">
@@ -58,8 +58,10 @@ ${tiles.poll.widget(c.proposal.adopt_poll, cls='big', delegate_url=delegate_url)
 
         <hr />
 
-        ${tiles.page.inline(c.proposal.description,
-                hide_discussion=c.instance.use_norms and len(c.proposal.selections))}
+        <div class="body">
+            ${tiles.page.inline(c.proposal.description,
+                    hide_discussion=c.instance.use_norms and len(c.proposal.selections))}
+        </div>
 
         ${components.social_share_buttons(c.proposal.title)}
 


### PR DESCRIPTION
Users can insert markdown in comments and proposals which works well for almost all elements but it is strange when they enter something like h1. This PR sets smaller styles for headings in comment and proposal bodies.

I would prefer a solution in which semantic elements like `section` and `article` influence the interpretation of headings (as defined in the [spec](http://www.w3.org/html/wg/drafts/html/master/sections.html#headings-and-sections)). But that would need much refactoring with our templates, so I propose this solution for now.
