### PR TITLE
use overlay format with htmlfill (fixes #580)

### DIFF
--- a/src/adhocracy/config/routing.py
+++ b/src/adhocracy/config/routing.py
@@ -26,7 +26,7 @@ def make_map(config):
 
     map.connect('/user/all', controller='user',
                 action='all', conditions=dict(method=['GET']))
-    map.connect('/user/{id}/badges', controller='user',
+    map.connect('/user/{id}/badges{.format}', controller='user',
                 action='edit_badges', conditions=dict(method=['GET']))
     map.connect('/user/{id}/badges', controller='user',
                 action='update_badges', conditions=dict(method=['POST']))
@@ -75,34 +75,34 @@ def make_map(config):
                 conditions=dict(method=['GET']))
     map.connect('/user/{id}/message/new', controller='message', action='new',
                 conditions=dict(method=['GET']))
-    map.connect('/user/{id}/settings',
+    map.connect('/user/{id}/settings{.format}',
                 controller='user', action='settings_personal',
                 conditions=dict(method=['GET']))
-    map.connect('/user/{id}/settings',
+    map.connect('/user/{id}/settings{.format}',
                 controller='user', action='settings_personal_update',
                 conditions=dict(method=['PUT']))
-    map.connect('/user/{id}/settings/login',
+    map.connect('/user/{id}/settings/login{.format}',
                 controller='user', action='settings_login',
                 conditions=dict(method=['GET']))
-    map.connect('/user/{id}/settings/login',
+    map.connect('/user/{id}/settings/login{.format}',
                 controller='user', action='settings_login_update',
                 conditions=dict(method=['PUT']))
-    map.connect('/user/{id}/settings/notifications',
+    map.connect('/user/{id}/settings/notifications{.format}',
                 controller='user', action='settings_notifications',
                 conditions=dict(method=['GET']))
-    map.connect('/user/{id}/settings/notifications',
+    map.connect('/user/{id}/settings/notifications{format}',
                 controller='user', action='settings_notifications_update',
                 conditions=dict(method=['PUT']))
-    map.connect('/user/{id}/settings/advanced',
+    map.connect('/user/{id}/settings/advanced{.format}',
                 controller='user', action='settings_advanced',
                 conditions=dict(method=['GET']))
-    map.connect('/user/{id}/settings/advanced',
+    map.connect('/user/{id}/settings/advanced{.format}',
                 controller='user', action='settings_advanced_update',
                 conditions=dict(method=['PUT']))
-    map.connect('/user/{id}/settings/optional',
+    map.connect('/user/{id}/settings/optional{.format}',
                 controller='user', action='settings_optional',
                 conditions=dict(method=['GET']))
-    map.connect('/user/{id}/settings/optional',
+    map.connect('/user/{id}/settings/optional{.format}',
                 controller='user', action='settings_optional_update',
                 conditions=dict(method=['PUT']))
 
@@ -296,18 +296,18 @@ def make_map(config):
                                          'ask_delete': 'GET',
                                          'widget': 'GET'})
 
-    map.connect('/badge', controller='badge', action='index',
+    map.connect('/badge{.format}', controller='badge', action='index',
                 conditions=dict(method=['GET']))
-    map.connect('/badge/{badge_type}/add', controller='badge',
+    map.connect('/badge/{badge_type}/add{.format}', controller='badge',
                 action='add', conditions=dict(method=['GET']))
-    map.connect('/badge/{badge_type}/add', controller='badge',
+    map.connect('/badge/{badge_type}/add{.format}', controller='badge',
                 action='create', conditions=dict(method=['POST']))
-    map.connect('/badge/edit/{id}', controller='badge',
+    map.connect('/badge/edit/{id}{.format}', controller='badge',
                 action="edit", conditions=dict(method=['GET']))
-    map.connect('/badge/edit/{id}',
+    map.connect('/badge/edit/{id}{.format}',
                 controller='badge', action="update",
                 conditions=dict(method=['POST']))
-    map.connect('/badge/delete/{id}',
+    map.connect('/badge/delete/{id}{.format}',
                 controller='badge', action="ask_delete",
                 conditions=dict(method=['GET']))
     map.connect('/badge/delete/{id}',
@@ -335,7 +335,7 @@ def make_map(config):
     map.connect('/tutorials', controller='root', action='tutorials')
 
     map.connect('/search/filter', controller='search', action='filter')
-    map.connect('/search', controller='search', action='query')
+    map.connect('/search{.format}', controller='search', action='query')
 
     map.connect('/abuse/report', controller='abuse', action='report')
     map.connect('/abuse/new', controller='abuse', action='new')
@@ -344,68 +344,68 @@ def make_map(config):
                 controller='instance', action='icon')
     map.connect('/instance/{id}_{y}.png',
                 controller='instance', action='icon')
-    map.connect('/instance/{id}/settings',
+    map.connect('/instance/{id}/settings{.format}',
                 controller='instance', action='settings_general',
                 conditions=dict(method=['GET']))
-    map.connect('/instance/{id}/settings',
+    map.connect('/instance/{id}/settings{.format}',
                 controller='instance', action='settings_general_update',
                 conditions=dict(method=['PUT']))
-    map.connect('/instance/{id}/settings/appearance',
+    map.connect('/instance/{id}/settings/appearance{.format}',
                 controller='instance', action='settings_appearance',
                 conditions=dict(method=['GET']))
-    map.connect('/instance/{id}/settings/appearance',
+    map.connect('/instance/{id}/settings/appearance{.format}',
                 controller='instance', action='settings_appearance_update',
                 conditions=dict(method=['PUT']))
-    map.connect('/instance/{id}/settings/contents',
+    map.connect('/instance/{id}/settings/contents{.format}',
                 controller='instance', action='settings_contents',
                 conditions=dict(method=['GET']))
-    map.connect('/instance/{id}/settings/contents',
+    map.connect('/instance/{id}/settings/contents{.format}',
                 controller='instance', action='settings_contents_update',
                 conditions=dict(method=['PUT']))
-    map.connect('/instance/{id}/settings/voting',
+    map.connect('/instance/{id}/settings/voting{.format}',
                 controller='instance', action='settings_voting',
                 conditions=dict(method=['GET']))
-    map.connect('/instance/{id}/settings/voting',
+    map.connect('/instance/{id}/settings/voting{.format}',
                 controller='instance', action='settings_voting_update',
                 conditions=dict(method=['PUT']))
-    map.connect('/instance/{id}/settings/badges',
+    map.connect('/instance/{id}/settings/badges{.format}',
                 controller='instance', action='settings_badges',
                 conditions=dict(method=['GET']))
-    map.connect('/instance/{id}/settings/badges',
+    map.connect('/instance/{id}/settings/badges{.format}',
                 controller='instance', action='settings_badges_update',
                 conditions=dict(method=['PUT']))
-    map.connect('/instance/{id}/settings/badges/{badge_type}/add',
+    map.connect('/instance/{id}/settings/badges/{badge_type}/add{.format}',
                 controller='instance',
                 action='settings_badges_add', conditions=dict(method=['GET']))
-    map.connect('/instance/{id}/settings/badges/{badge_type}/add',
+    map.connect('/instance/{id}/settings/badges/{badge_type}/add{.format}',
                 controller='instance',
                 action='settings_badges_create',
                 conditions=dict(method=['POST']))
-    map.connect('/instance/{id}/settings/badges/edit/{badge_id}',
+    map.connect('/instance/{id}/settings/badges/edit/{badge_id}{.format}',
                 controller='instance',
                 action="settings_badges_edit", conditions=dict(method=['GET']))
-    map.connect('/instance/{id}/settings/badges/edit/{badge_id}',
+    map.connect('/instance/{id}/settings/badges/edit/{badge_id}{.format}',
                 controller='instance', action="settings_badges_update",
                 conditions=dict(method=['POST']))
-    map.connect('/instance/{id}/settings/badges/delete/{badge_id}',
+    map.connect('/instance/{id}/settings/badges/delete/{badge_id}{.format}',
                 controller='instance', action="settings_badges_ask_delete",
                 conditions=dict(method=['GET']))
-    map.connect('/instance/{id}/settings/badges/delete/{badge_id}',
+    map.connect('/instance/{id}/settings/badges/delete/{badge_id}{.format}',
                 controller='instance', action="settings_badges_delete",
                 conditions=dict(method=['POST']))
-    map.connect('/instance/{id}/settings/massmessage',
+    map.connect('/instance/{id}/settings/massmessage{.format}',
                 controller='massmessage', action='new',
                 conditions=dict(method=['GET']))
-    map.connect('/instance/{id}/settings/massmessage',
+    map.connect('/instance/{id}/settings/massmessage{.format}',
                 controller='massmessage', action='create',
                 conditions=dict(method=['POST']))
-    map.connect('/instance/{id}/settings/massmessage/preview',
+    map.connect('/instance/{id}/settings/massmessage/preview{.format}',
                 controller='massmessage', action='preview',
                 conditions=dict(method=['POST']))
-    map.connect('/instance/{id}/settings/members_import',
+    map.connect('/instance/{id}/settings/members_import{.format}',
                 controller='instance', action='settings_members_import',
                 conditions=dict(method=['GET']))
-    map.connect('/instance/{id}/settings/members_import',
+    map.connect('/instance/{id}/settings/members_import{.format}',
                 controller='instance', action='settings_members_import_save',
                 conditions=dict(method=['PUT', 'POST']))
 
@@ -422,15 +422,15 @@ def make_map(config):
     map.connect('/stats/', controller='stats')
 
     map.connect('/admin', controller='admin', action="index")
-    map.connect('/admin/users/import', controller='admin',
+    map.connect('/admin/users/import{.format}', controller='admin',
                 action="user_import", conditions=dict(method=['POST']))
-    map.connect('/admin/users/import', controller='admin',
+    map.connect('/admin/users/import{.format}', controller='admin',
                 action="user_import_form", conditions=dict(method=['GET']))
     map.connect('/admin/export',
                 controller='admin', action='export_dialog')
     map.connect('/admin/export/do',
                 controller='admin', action='export_do')
-    map.connect('/admin/import',
+    map.connect('/admin/import{.format}',
                 controller='admin', action='import_dialog')
     map.connect('/admin/import/do',
                 controller='admin', action='import_do')
@@ -446,18 +446,18 @@ def make_map(config):
     map.connect('/admin/treatment/{key}/assigned',
                 controller='treatment', action='assigned')
 
-    map.connect('/static/', controller='static', action='index',
+    map.connect('/static{.format}', controller='static', action='index',
                 conditions=dict(method=['GET', 'HEAD']))
-    map.connect('/static/', controller='static', action='make_new',
+    map.connect('/static{.format}', controller='static', action='make_new',
                 conditions=dict(method=['POST']))
-    map.connect('/static/new', controller='static', action='new')
+    map.connect('/static/new{.format}', controller='static', action='new')
     map.connect('/static/{key}_{lang}',
                 controller='static', action='edit',
                 conditions=dict(method=['GET', 'HEAD']))
-    map.connect('/static/{key}_{lang}',
+    map.connect('/static/{key}_{lang}{.format}',
                 controller='static', action='update',
                 conditions=dict(method=['POST']))
-    map.connect('/static/{key}.{format}', controller='static',
+    map.connect('/static/{key}{.format}', controller='static',
                 action='serve')
     map.connect('/outgoing_link/{url_enc}', controller='redirect',
                 action='outgoing_link',

--- a/src/adhocracy/controllers/abuse.py
+++ b/src/adhocracy/controllers/abuse.py
@@ -30,7 +30,7 @@ class AbuseController(BaseController):
     def new(self, format='html', errors={}):
         c.url = request.params.get('url', request.environ.get('HTTP_REFERER'))
         #require.user.message(c.page_user)
-        html = render("/abuse/new.html")
+        html = render("/abuse/new.html", overlay=format == u'overlay')
         return htmlfill.render(html, defaults=request.params,
                                errors=errors, force_defaults=False)
 

--- a/src/adhocracy/controllers/badge.py
+++ b/src/adhocracy/controllers/badge.py
@@ -124,7 +124,7 @@ class BadgeController(BaseController):
     def index(self, format='html'):
         c.badges = self._available_badges()
         c.badge_base_url = self.base_url
-        return render(self.index_template)
+        return render(self.index_template, overlay=format == u'overlay')
 
     def _redirect_not_found(self, id):
         h.flash(_("We cannot find the badge with the id %s") % str(id),
@@ -153,7 +153,7 @@ class BadgeController(BaseController):
                 key=lambda x: x[1])
 
     @guard.instance.any_admin()
-    def add(self, badge_type=None, errors=None):
+    def add(self, badge_type=None, errors=None, format=u''):
         data = {
             'form_type': 'add',
             'groups': Group.all_instance(),
@@ -170,7 +170,7 @@ class BadgeController(BaseController):
 
         self._set_parent_categories()
 
-        html = render(self.form_template, data)
+        html = render(self.form_template, data, overlay=format == u'overlay')
         return htmlfill.render(html,
                                defaults=defaults,
                                errors=errors,
@@ -332,7 +332,7 @@ class BadgeController(BaseController):
         return badge
 
     @guard.instance.any_admin()
-    def edit(self, id, errors=None):
+    def edit(self, id, errors=None, format=u'html'):
         badge = self._get_badge_or_redirect(id)
         data = {
             'badge_type': self._get_badge_type(badge),
@@ -366,7 +366,8 @@ class BadgeController(BaseController):
             defaults['select_child_description'] =\
                 badge.select_child_description
 
-        return htmlfill.render(render(self.form_template, data),
+        return htmlfill.render(render(self.form_template, data,
+                                      overlay=format == u'overlay'),
                                errors=errors,
                                defaults=defaults,
                                force_defaults=False)
@@ -520,7 +521,7 @@ class BadgeController(BaseController):
         redirect(self.base_url)
 
     @guard.instance.any_admin()
-    def ask_delete(self, id):
+    def ask_delete(self, id, format=u'html'):
         badge = self._get_badge_or_redirect(id)
 
         data = {
@@ -530,7 +531,8 @@ class BadgeController(BaseController):
             'return_url': self.base_url,
         }
 
-        return render('/badge/ask_delete.html', data)
+        return render('/badge/ask_delete.html', data,
+                      overlay=format == u'overlay')
 
     @guard.instance.any_admin()
     @RequireInternalRequest()

--- a/src/adhocracy/controllers/comment.py
+++ b/src/adhocracy/controllers/comment.py
@@ -91,7 +91,7 @@ class CommentController(BaseController):
         if format == 'ajax':
             html = self._render_ajax_create_form(c.reply, c.topic, c.variant)
         else:
-            html = render('/comment/new.html')
+            html = render('/comment/new.html', overlay=format == u'overlay')
         return htmlfill.render(html, defaults=defaults,
                                errors=errors, force_defaults=False)
 
@@ -192,13 +192,14 @@ class CommentController(BaseController):
             redirect(h.entity_url(c.comment))
         elif format == 'json':
             return render_json(c.comment)
-        return render('/comment/show.html')
+        return render('/comment/show.html', overlay=format == u'overlay')
 
     @RequireInstance
-    def ask_delete(self, id):
+    def ask_delete(self, id, format=u'html'):
         c.comment = get_entity_or_abort(model.Comment, id)
         require.comment.delete(c.comment)
-        return render('/comment/ask_delete.html')
+        return render('/comment/ask_delete.html',
+                      overlay=format == u'overlay')
 
     @RequireInstance
     @csrf.RequireInternalRequest()

--- a/src/adhocracy/controllers/delegation.py
+++ b/src/adhocracy/controllers/delegation.py
@@ -50,10 +50,10 @@ class DelegationController(BaseController):
     @RequireInstance
     @validate(schema=DelegationNewForm(), form="bad_request",
               post_only=False, on_get=True)
-    def new(self):
+    def new(self, format=u'html'):
         c.scope = self.form_result.get('scope')
         require.delegation.create(c.scope)
-        return render("/delegation/new.html")
+        return render("/delegation/new.html", overlay=format == u'overlay')
 
     @RequireInstance
     @csrf.RequireInternalRequest(methods=["POST"])

--- a/src/adhocracy/controllers/instance.py
+++ b/src/adhocracy/controllers/instance.py
@@ -167,7 +167,7 @@ class InstanceController(BaseController):
             return render("/instance/index.html")
 
     @guard.instance.create()
-    def new(self):
+    def new(self, format=u'html'):
 
         data = {}
         protocol = config.get('adhocracy.protocol').strip()
@@ -182,7 +182,8 @@ class InstanceController(BaseController):
             data['url_post'] = '.%s' % domain
             data['url_right_align'] = True
 
-        return render("/instance/new.html", data)
+        return render("/instance/new.html", data,
+                      overlay=format == u'overlay')
 
     @csrf.RequireInternalRequest(methods=['POST'])
     @guard.instance.create()
@@ -344,7 +345,7 @@ class InstanceController(BaseController):
             return render_json(json)
         else:
             return formencode.htmlfill.render(
-                render("/instance/badges.html"),
+                render("/instance/badges.html", overlay=format == u'overlay'),
                 defaults=defaults)
 
     @validate(schema=InstanceBadgesForm(), form='badges')
@@ -453,7 +454,7 @@ class InstanceController(BaseController):
         return render("/instance/settings_general.html")
 
     @RequireInstance
-    def settings_general(self, id):
+    def settings_general(self, id, format=u'html'):
         c.page_instance = self._get_current_instance(id)
         require.instance.edit(c.page_instance)
         form_content = self._settings_general_form(id)

--- a/src/adhocracy/controllers/massmessage.py
+++ b/src/adhocracy/controllers/massmessage.py
@@ -145,7 +145,7 @@ class MassmessageController(BaseController):
 
         return sender_options
 
-    def new(self, id=None, errors={}):
+    def new(self, id=None, errors={}, format=u'html'):
 
         if id is None:
             require.perm('global.message')
@@ -170,7 +170,8 @@ class MassmessageController(BaseController):
                                         include_global=True)
         }
 
-        return htmlfill.render(render(template, data),
+        return htmlfill.render(render(template, data,
+                                      overlay=format == u'overlay'),
                                defaults=defaults, errors=errors,
                                force_defaults=False)
 

--- a/src/adhocracy/controllers/message.py
+++ b/src/adhocracy/controllers/message.py
@@ -27,7 +27,7 @@ class MessageController(BaseController):
     def new(self, id, format='html', errors={}):
         c.page_user = get_entity_or_abort(model.User, id)
         require.user.message(c.page_user)
-        html = render("/message/new.html")
+        html = render("/message/new.html", overlay=format == u'overlay')
         return htmlfill.render(html, defaults=request.params,
                                errors=errors, force_defaults=False)
 

--- a/src/adhocracy/controllers/milestone.py
+++ b/src/adhocracy/controllers/milestone.py
@@ -91,12 +91,13 @@ class MilestoneController(BaseController):
     @RequireInstance
     @validate(schema=MilestoneNewForm(), form='bad_request',
               post_only=False, on_get=True)
-    def new(self, errors=None):
+    def new(self, errors=None, format=u'html'):
         require.milestone.create()
         c.categories = model.CategoryBadge.all(instance=c.instance)
         defaults = dict(request.params)
         defaults['watch'] = defaults.get('watch', True)
-        return htmlfill.render(render("/milestone/new.html"),
+        return htmlfill.render(render("/milestone/new.html",
+                                      overlay=format == u'overlay'),
                                defaults=defaults, errors=errors,
                                force_defaults=False)
 

--- a/src/adhocracy/controllers/page.py
+++ b/src/adhocracy/controllers/page.py
@@ -140,7 +140,7 @@ class PageController(BaseController):
 
     @RequireInstance
     @guard.page.create()
-    def new(self, errors=None):
+    def new(self, errors=None, format=u'html'):
         defaults = dict(request.params)
         defaults['watch'] = defaults.get('watch', True)
         c.title = request.params.get('title', None)
@@ -158,10 +158,11 @@ class PageController(BaseController):
         html = None
         if proposal_id is not None:
             c.proposal = model.Proposal.find(proposal_id)
-            html = render('/selection/propose.html')
+            html = render('/selection/propose.html',
+                          overlay=format == u'overlay')
         else:
             c.propose = None
-            html = render("/page/new.html")
+            html = render("/page/new.html", overlay=format == u'overlay')
 
         return htmlfill.render(html, defaults=defaults, errors=errors,
                                force_defaults=False)
@@ -226,7 +227,8 @@ class PageController(BaseController):
 
     @RequireInstance
     @validate(schema=PageEditForm(), form='edit', post_only=False, on_get=True)
-    def edit(self, id, variant=None, text=None, branch=False, errors={}):
+    def edit(self, id, variant=None, text=None, branch=False, errors={},
+             format=u'html'):
         c.page, c.text, c.variant = self._get_page_and_text(id, variant, text)
         c.variant = request.params.get("variant", c.variant)
         c.proposal = request.params.get("proposal")
@@ -271,7 +273,7 @@ class PageController(BaseController):
 
         c.text_rows = libtext.text_rows(c.text)
         c.left = c.page.head
-        html = render('/page/edit.html')
+        html = render('/page/edit.html', overlay=format == u'overlay')
         return htmlfill.render(html, defaults=defaults,
                                errors=errors, force_defaults=False)
 

--- a/src/adhocracy/controllers/proposal.py
+++ b/src/adhocracy/controllers/proposal.py
@@ -203,7 +203,8 @@ class ProposalController(BaseController):
 
         defaults = dict(request.params)
         defaults['watch'] = defaults.get('watch', True)
-        return htmlfill.render(render("/proposal/new.html"),
+        return htmlfill.render(render("/proposal/new.html",
+                                      overlay=format == u'overlay'),
                                defaults=defaults, errors=errors,
                                force_defaults=False)
 
@@ -288,7 +289,7 @@ class ProposalController(BaseController):
     @RequireInstance
     @validate(schema=ProposalEditForm(), form="bad_request",
               post_only=False, on_get=True)
-    def edit(self, id, errors={}, page=None):
+    def edit(self, id, errors={}, page=None, format=u'html'):
         c.proposal = get_entity_or_abort(model.Proposal, id)
         require.proposal.edit(c.proposal)
         c.can_edit_wiki = self._can_edit_wiki(c.proposal, c.user)
@@ -310,7 +311,8 @@ class ProposalController(BaseController):
             defaults['watch'] = h.find_watch(c.proposal) is not None
             defaults['frozen'] = c.proposal.frozen
         defaults.update({"category": c.category.id if c.category else None})
-        return htmlfill.render(render("/proposal/edit.html"),
+        return htmlfill.render(render("/proposal/edit.html",
+                                      overlay=format == u'overlay'),
                                defaults=defaults,
                                errors=errors, force_defaults=force_defaults)
 
@@ -608,7 +610,7 @@ class ProposalController(BaseController):
             return render_json(json)
         else:
             return formencode.htmlfill.render(
-                render("/proposal/badges.html"),
+                render("/proposal/badges.html", overlay=format == u'overlay'),
                 defaults=defaults)
 
     @RequireInternalRequest()

--- a/src/adhocracy/controllers/search.py
+++ b/src/adhocracy/controllers/search.py
@@ -30,10 +30,11 @@ class SearchController(BaseController):
     @guard.proposal.index()
     @validate(schema=SearchQueryForm(), form="_search_form",
               post_only=False, on_get=True)
-    def query(self):
+    def query(self, format=u'html'):
         c.query = self.form_result.get("serp_q", u"*:*")
         self._query_pager()
-        return formencode.htmlfill.render(render("search/results.html"),
+        html = render("search/results.html", overlay=format == u'overlay'),
+        return formencode.htmlfill.render(html,
                                           {'q': c.query, 'serp_q': c.query})
 
     @guard.proposal.index()

--- a/src/adhocracy/controllers/selection.py
+++ b/src/adhocracy/controllers/selection.py
@@ -35,14 +35,16 @@ class SelectionController(BaseController):
 
     @RequireInstance
     @guard.norm.propose()
-    def propose(self, proposal_id, errors=None):
-        return self._new(proposal_id, '/selection/propose.html', errors)
+    def propose(self, proposal_id, errors=None, format=u'html'):
+        return self._new(proposal_id, '/selection/propose.html', errors,
+                         format=format)
 
     @RequireInstance
-    def include(self, proposal_id, errors={}):
-        return self._new(proposal_id, '/selection/include.html', errors)
+    def include(self, proposal_id, errors={}, format=u'html'):
+        return self._new(proposal_id, '/selection/include.html', errors,
+                         format=format)
 
-    def _new(self, proposal_id, template, errors):
+    def _new(self, proposal_id, template, errors, format=u'html'):
         c.proposal = get_entity_or_abort(model.Proposal, proposal_id)
         require.selection.create(c.proposal)
         defaults = dict(request.params)
@@ -55,7 +57,8 @@ class SelectionController(BaseController):
         q = q.filter(model.Page.allow_selection == False)  # noqa
         c.exclude_pages += q.all()
 
-        return htmlfill.render(render(template), defaults=defaults,
+        html = render(template, overlay=format == u'overlay')
+        return htmlfill.render(html, defaults=defaults,
                                errors=errors, force_defaults=False)
 
     @RequireInstance

--- a/src/adhocracy/controllers/static.py
+++ b/src/adhocracy/controllers/static.py
@@ -43,13 +43,14 @@ class StaticController(BaseController):
         return render('/static/index.html', data)
 
     @guard_perms
-    def new(self, errors=None):
+    def new(self, errors=None, format=u'html'):
         data = {
             'all_language_infos': list(all_language_infos())
         }
         defaults = dict(request.params)
         defaults['_tok'] = csrf.token_id()
-        return htmlfill.render(render('/static/new.html', data),
+        return htmlfill.render(render('/static/new.html', data,
+                                      overlay=format == u'overlay'),
                                defaults=defaults, errors=errors)
 
     @guard_perms
@@ -77,7 +78,7 @@ class StaticController(BaseController):
         return redirect(helpers.base_url('/static/'))
 
     @guard_perms
-    def edit(self, key, lang, errors=None):
+    def edit(self, key, lang, errors=None, format=u'html'):
         backend = get_backend()
         sp = backend.get(key, lang)
         if not sp:
@@ -89,7 +90,8 @@ class StaticController(BaseController):
         }
         defaults.update(dict(request.params))
         defaults['_tok'] = csrf.token_id()
-        return htmlfill.render(render('/static/edit.html', data),
+        return htmlfill.render(render('/static/edit.html', data,
+                                      overlay=format == u'overlay'),
                                defaults=defaults, errors=errors)
 
     @guard_perms

--- a/src/adhocracy/controllers/user.py
+++ b/src/adhocracy/controllers/user.py
@@ -191,7 +191,7 @@ class UserController(BaseController):
         c.users_pager = solr_global_users_pager()
         return render("/user/all.html")
 
-    def new(self, defaults=None):
+    def new(self, defaults=None, format=u'html'):
         if not h.allow_user_registration():
             return ret_abort(
                 _("Sorry, registration has been disabled by administrator."),
@@ -209,7 +209,8 @@ class UserController(BaseController):
             defaults['_tok'] = token_id()
             add_static_content(data, u'adhocracy.static_agree_text',
                                body_key=u'agree_text', title_key='_ignored')
-            return htmlfill.render(render("/user/register.html", data),
+            return htmlfill.render(render("/user/register.html", data,
+                                          overlay=format == u'overlay'),
                                    defaults=defaults)
 
     @RequireInternalRequest(methods=['POST'])
@@ -346,7 +347,7 @@ class UserController(BaseController):
         if c.instance is None:
             c.active_global_nav = 'user'
 
-    def _settings_personal_form(self, id):
+    def _settings_personal_form(self, id, format=u'html'):
         self._settings_all(id)
         c.settings_menu = settings_menu(c.page_user, 'personal')
 
@@ -362,10 +363,11 @@ class UserController(BaseController):
             {'value': u'm', 'label': _(u'Male')},
         ]
 
-        return render("/user/settings_personal.html")
+        return render("/user/settings_personal.html",
+                      overlay=format == u'overlay')
 
-    def settings_personal(self, id):
-        form_content = self._settings_personal_form(id)
+    def settings_personal(self, id, format=u'html'):
+        form_content = self._settings_personal_form(id, format=format)
         return htmlfill.render(
             form_content,
             defaults={
@@ -395,7 +397,7 @@ class UserController(BaseController):
 
         return self._settings_result(updated, c.page_user, 'personal')
 
-    def _settings_login_form(self, id):
+    def _settings_login_form(self, id, format=u'html'):
         self._settings_all(id)
         c.settings_menu = settings_menu(c.page_user, 'login')
         c.locales = []
@@ -404,10 +406,11 @@ class UserController(BaseController):
                               'label': locale.display_name,
                               'selected': locale == c.user.locale})
 
-        return render("/user/settings_login.html")
+        return render("/user/settings_login.html",
+                      overlay=format == u'overlay')
 
-    def settings_login(self, id):
-        form_content = self._settings_login_form(id)
+    def settings_login(self, id, format=u'html'):
+        form_content = self._settings_login_form(id, format=format)
         return htmlfill.render(
             form_content,
             defaults={
@@ -433,7 +436,7 @@ class UserController(BaseController):
 
         return self._settings_result(updated, c.page_user, 'login')
 
-    def _settings_notifications_form(self, id):
+    def _settings_notifications_form(self, id, format=u'html'):
         self._settings_all(id)
         c.settings_menu = settings_menu(c.page_user, 'notifications')
 
@@ -443,10 +446,11 @@ class UserController(BaseController):
                               'label': locale.display_name,
                               'selected': locale == c.user.locale})
 
-        return render("/user/settings_notifications.html")
+        return render("/user/settings_notifications.html",
+                      overlay=format == u'overlay')
 
-    def settings_notifications(self, id):
-        form_content = self._settings_notifications_form(id)
+    def settings_notifications(self, id, format=u'html'):
+        form_content = self._settings_notifications_form(id, format=format)
         return htmlfill.render(
             form_content,
             defaults={
@@ -488,7 +492,7 @@ class UserController(BaseController):
         #    model.meta.Session.add(c.page_user.twitter)
         return self._settings_result(updated, c.page_user, 'notifications')
 
-    def _settings_advanced_form(self, id):
+    def _settings_advanced_form(self, id, format=u'html'):
         self._settings_all(id)
         c.tile = tiles.user.UserTile(c.page_user)
         c.settings_menu = settings_menu(c.page_user, 'advanced')
@@ -499,10 +503,11 @@ class UserController(BaseController):
                          for size in [10, 20, 50, 100, 200]]
         c.sorting_orders = PROPOSAL_SORTS
 
-        return render("/user/settings_advanced.html")
+        return render("/user/settings_advanced.html",
+                      overlay=format == u'overlay')
 
-    def settings_advanced(self, id):
-        form_content = self._settings_advanced_form(id)
+    def settings_advanced(self, id, format=u'html'):
+        form_content = self._settings_advanced_form(id, format=format)
         return htmlfill.render(
             form_content,
             defaults={
@@ -526,7 +531,7 @@ class UserController(BaseController):
 
         return self._settings_result(updated, c.page_user, 'advanced')
 
-    def _settings_optional_form(self, id, data={}):
+    def _settings_optional_form(self, id, data={}, format=u'html'):
         if not config.get('adhocracy.user.optional_attributes'):
             abort(400, _("No optional attributes defined."))
         self._settings_all(id)
@@ -538,10 +543,11 @@ class UserController(BaseController):
         add_static_content(data,
                            u'adhocracy.static_optional_path')
 
-        return render("/user/settings_optional.html", data)
+        return render("/user/settings_optional.html", data,
+                      overlay=format == u'overlay')
 
-    def settings_optional(self, id):
-        form_content = self._settings_optional_form(id)
+    def settings_optional(self, id, format=u'html'):
+        form_content = self._settings_optional_form(id, format=format)
         defaults = c.page_user.optional_attributes or {}
 
         # Workaround, as htmlfill will match select option values in their
@@ -780,7 +786,7 @@ class UserController(BaseController):
         else:
             return self._render_loginform()
 
-    def _render_loginform(self, errors=None, defaults=None):
+    def _render_loginform(self, errors=None, defaults=None, format=u'html'):
         if defaults is None:
             defaults = dict(request.params)
             defaults.setdefault('have_password', 'true')
@@ -792,11 +798,13 @@ class UserController(BaseController):
             config.get_bool('adhocracy.hide_locallogin')
             and not 'locallogin' in request.GET)
         add_static_content(data, u'adhocracy.static_login_path')
-        form = render('/user/login_tile.html', data)
+        form = render('/user/login_tile.html', data,
+                      overlay=format == u'overlay')
         form = htmlfill.render(form,
                                errors=errors,
                                defaults=defaults)
-        return render('/user/login.html', {'login_form_code': form})
+        return render('/user/login.html', {'login_form_code': form},
+                      overlay=format == u'overlay')
 
     def perform_login(self):
         pass  # managed by repoze.who
@@ -1194,12 +1202,12 @@ class UserController(BaseController):
         return set(allowed[0]).union(set(allowed[1]))
 
     @guard.perm('instance.admin')
-    def edit_badges(self, id, errors=None):
+    def edit_badges(self, id, errors=None, format=u'html'):
         c.badges, c.instance_badges = self._allowed_badges()
         c.page_user = get_entity_or_abort(model.User, id)
         defaults = {'badge': [str(badge.id) for badge in c.page_user.badges]}
         return formencode.htmlfill.render(
-            render("/user/badges.html"),
+            render("/user/badges.html", overlay=format == u'overlay'),
             defaults=defaults,
             force_defaults=False)
 


### PR DESCRIPTION
In this PR I added the `format` parameters to many controller actions which did not support it before as described in #580. Especially I added support for `overlay` format with many actions which use the `htmlfill.render` function. Still this does not cover everything but it is a good step forward.
