### PR TITLE
redirect startpage to instance

### DIFF
--- a/src/adhocracy/config/__init__.py
+++ b/src/adhocracy/config/__init__.py
@@ -47,6 +47,7 @@ DEFAULTS = {
     'adhocracy.use_feedback_instance': False,
     'adhocracy.user.optional_attributes': [],
     'adhocracy.wording.intro_for_overview': False,
+    'adhocracy.redirect_startpage_to_instance': u'',
     'debug': False,
 }
 

--- a/src/adhocracy/controllers/root.py
+++ b/src/adhocracy/controllers/root.py
@@ -35,6 +35,11 @@ class RootController(BaseController):
         if format == 'rss':
             return EventController().all(format='rss')
 
+        name = config.get('adhocracy.redirect_startpage_to_instance')
+        if name != u'':
+            instance = model.Instance.find(name)
+            redirect(h.entity_url(instance))
+
         data = {}
 
         instances_in_root = config.get_int(


### PR DESCRIPTION
This adds an installation wide setting to set an instance the startpage should redirect to.
