### PR TITLE
Allow to hide proposals navigation item

### DIFF
--- a/src/adhocracy/controllers/instance.py
+++ b/src/adhocracy/controllers/instance.py
@@ -107,6 +107,8 @@ class InstanceContentsEditForm(formencode.Schema):
         not_empty=False, if_empty=False, if_missing=False)
     show_norms_navigation = validators.StringBool(
         not_empty=False, if_empty=False, if_missing=False)
+    show_proposals_navigation = validators.StringBool(
+        not_empty=False, if_empty=False, if_missing=False)
     require_selection = validators.StringBool(
         not_empty=False, if_empty=False, if_missing=False)
     frozen = validators.StringBool(
@@ -582,6 +584,8 @@ class InstanceController(BaseController):
                 'editable_comments_default':
                 instance.editable_comments_default,
                 'show_norms_navigation': instance.show_norms_navigation,
+                'show_proposals_navigation':
+                instance.show_proposals_navigation,
                 'frozen': instance.frozen,
                 '_tok': csrf.token_id()})
 
@@ -599,7 +603,8 @@ class InstanceController(BaseController):
             ['allow_propose', 'allow_index', 'frozen', 'milestones',
              'use_norms', 'require_selection', 'allow_propose_changes',
              'hide_global_categories', 'editable_comments_default',
-             'show_norms_navigation', 'allow_thumbnailbadges'])
+             'show_norms_navigation', 'show_proposals_navigation',
+             'allow_thumbnailbadges'])
         return self._settings_result(updated, c.page_instance, 'contents')
 
     def _settings_voting_form(self, id):

--- a/src/adhocracy/migration/versions/075_show_proposals_navigation.py
+++ b/src/adhocracy/migration/versions/075_show_proposals_navigation.py
@@ -1,0 +1,19 @@
+from sqlalchemy import MetaData
+from sqlalchemy import Column, ForeignKey, Table, func
+from sqlalchemy import Boolean, DateTime, Float, Integer, Unicode, UnicodeText
+
+metadata = MetaData()
+
+
+def upgrade(migrate_engine):
+    metadata.bind = migrate_engine
+
+    instance_table = Table('instance', metadata, autoload=True)
+    show_norms_navigation = Column('show_proposals_navigation',
+                                   Boolean,
+                                   default=True)
+    show_norms_navigation.create(instance_table)
+
+
+def downgrade(migrate_engine):
+    raise NotImplementedError()

--- a/src/adhocracy/model/instance.py
+++ b/src/adhocracy/model/instance.py
@@ -53,6 +53,7 @@ instance_table = Table(
     Column('thumbnailbadges_height', Integer, nullable=True),
     Column('thumbnailbadges_width', Integer, nullable=True),
     Column('show_norms_navigation', Boolean, nullable=True, default=True),
+    Column('show_proposals_navigation', Boolean, nullable=True, default=True),
 )
 
 

--- a/src/adhocracy/templates/instance/settings_contents.html
+++ b/src/adhocracy/templates/instance/settings_contents.html
@@ -10,7 +10,7 @@
 <%block name="settings_content">
 <form name="create_instance" class="well" method="POST"
       enctype="multipart/form-data">
-    
+
     ${components.flashmessages()}
 
     <h2>${c.settings_menu.current['label']}</h2>
@@ -18,15 +18,16 @@
     <input type="hidden" name="_method" value="PUT" />
 
     ${h.field_token()|n}
-    
+
     ${forms.checkbox(_("Use Norms"), 'use_norms', '1')}
     <div style="padding-left: 2em;">
-    ${forms.checkbox(_("Allow users to propose norms"), 'allow_propose', '5')}
-    ${forms.checkbox(_("Allow users to change norms from within proposals"), 'allow_propose_changes', '5')}
-    ${forms.checkbox(_("Require to propose a variant"), 'require_selection', '10')}
-    ${forms.checkbox(_("Show norms navigation item"), 'show_norms_navigation', '12')}
+        ${forms.checkbox(_("Allow users to propose norms"), 'allow_propose', '5')}
+        ${forms.checkbox(_("Allow users to change norms from within proposals"), 'allow_propose_changes', '5')}
+        ${forms.checkbox(_("Require to propose a variant"), 'require_selection', '10')}
+        ${forms.checkbox(_("Show norms navigation item"), 'show_norms_navigation', '12')}
     </div>
 
+    ${forms.checkbox(_("Show proposals navigation item"), 'show_proposals_navigation', '13')}
     ${forms.checkbox(_("Use milestones"), 'milestones', 15)}
     ${forms.checkbox(_("Use thumbnail badges"), 'allow_thumbnailbadges', 16)}
     ${forms.checkbox(_("Hide global categories"), 'hide_global_categories', 17)}
@@ -34,5 +35,5 @@
     ${forms.checkbox(_("Freeze this instance"), 'frozen', 20)}
     ${components.savebox(h.base_url("/instance/%s" % c.page_instance.key))}
 
-</form> 
+</form>
 </%block>

--- a/src/adhocracy/templates/navigation.html
+++ b/src/adhocracy/templates/navigation.html
@@ -198,6 +198,7 @@
   ${nav_link(href=h.base_url('/proposal'),
              text=_("Proposals"),
              li_class=_class('proposals'),
+             condition=c.instance.show_proposals_navigation,
              id_='subnav-proposals')}
 
   ${nav_link(href=h.base_url('/milestone'),


### PR DESCRIPTION
This allows to hide the proposal navigation item on instance level (hey, another migration!). It does pretty much the same as 2a6965dd did for norms.
