### PR TITLE
Allow to assign user badges during user import

### DIFF
--- a/src/adhocracy/controllers/admin.py
+++ b/src/adhocracy/controllers/admin.py
@@ -3,6 +3,7 @@ import logging
 import formencode
 import formencode.htmlfill
 from pylons import config, request
+from pylons import tmpl_context as c
 from pylons.i18n import lazy_ugettext as L_, _
 from pylons.controllers.util import redirect
 
@@ -175,6 +176,10 @@ class AdminController(BaseController):
                 password = random_token()
                 user_info['password'] = password
                 user.password = password
+
+                for badge in user_info['user_badges']:
+                    badge.assign(user, creator=c.user)
+
                 model.meta.Session.add(user)
                 model.meta.Session.commit()
                 users.append(user)

--- a/src/adhocracy/templates/admin/userimport_form.html
+++ b/src/adhocracy/templates/admin/userimport_form.html
@@ -18,12 +18,13 @@ ${self.form()}
     ${h.field_token()|n}
 
     <div class="input_wrapper">
-        <%forms:textarea 
+        <%forms:textarea
             label="${_('Users CSV')}"
             name="users_csv"
             value=""
             tabindex="1"
-            help="${_('Paste the content of a CSV file, e.g. exported from Excel, with the 3 columns username, display name and email')}">
+            placeholder="testuser, &quot;Test User&quot;, test@example.com, &quot;badge1, badge2&quot;"
+            help="${_('Paste the content of a CSV file, e.g. exported from Excel, with the 4 columns username, display name, email and badges (badges are optional, comma separated and with quotes around the list)')}">
 
         </%forms:textarea>
 

--- a/src/adhocracy/templates/forms.html
+++ b/src/adhocracy/templates/forms.html
@@ -46,7 +46,7 @@
 </label>
 </%def>
 
-<%def name="textarea(label, name, value, tabindex=None, rows=3, cls='', help=None)">
+<%def name="textarea(label, name, value, tabindex=None, rows=3, cls='', placeholder='', help=None)">
 ## This renders a textarea like this:
 ##
 ## <label />
@@ -63,8 +63,9 @@
 %if hasattr(caller, 'before'):
 ${caller.before()}
 %endif
-<textarea class="${cls}" name="${name}" rows="${rows}" 
-          ${'tabindex="%s"' % tabindex if tabindex is not None else '' | n}>${value}</textarea>
+<textarea class="${cls}" name="${name}" rows="${rows}"
+          ${'tabindex="%s"' % tabindex if tabindex is not None else '' | n}
+          ${'placeholder="%s"' % placeholder if placeholder else '' | n}>${value}</textarea>
 %if hasattr(caller, 'after'):
 ${caller.after()}
 %endif


### PR DESCRIPTION
Global admins are allowed to assign global badges as well as instance
badges, while non-global admins can only assign instance badges.

To clarify the input format, a placeholder is added.
