### PR TITLE
[RFC] don't delete texts when deleting a page

### DIFF
--- a/src/adhocracy/model/page.py
+++ b/src/adhocracy/model/page.py
@@ -335,8 +335,6 @@ class Page(Delegateable):
     def delete(self, delete_time=None):
         if delete_time is None:
             delete_time = datetime.utcnow()
-        for text in self.texts:
-            text.delete(delete_time=delete_time)
         for selection in self.selections:
             selection.delete(delete_time=delete_time)
         if self.delete_time is None:


### PR DESCRIPTION
Many objects like pages and texts are not actually deleted but only marked as such. Currently when marking a page as deleted all of its text are marked as deleted as well. That way the page title (and probably other things) are not available anymore which looks strange in event messages.

> Daniel deleted (Unknown)

I am not sure if simply not deleting the texts is the right way to do it so I am open for feedback.
