### PR TITLE
no amendment badges

### DIFF
--- a/src/adhocracy/templates/proposal/edit.html
+++ b/src/adhocracy/templates/proposal/edit.html
@@ -43,7 +43,7 @@
         </fieldset>
 
         %if not h.config.get_bool('adhocracy.proposal.split_badge_edit'):
-        %if can.perm("instance.admin"):
+        %if can.perm("instance.admin") and not c.proposal.is_amendment:
         <fieldset>
             <legend>${_("badge")}</legend>
 


### PR DESCRIPTION
This disables assigning badges in the amendment edit dialog.

In case you wander why I bother you with this: To me it was obvious that amendments should not have badges. But maybe you have a different opinion on that.
