### PR TITLE
fix show "new milestone" button

### DIFF
--- a/src/adhocracy/templates/milestone/index.html
+++ b/src/adhocracy/templates/milestone/index.html
@@ -39,6 +39,7 @@ ${tiles.milestone.timeline(c.milestones)}
 <div id="milestones_table" class="table">
     ${c.past_milestones_pager.here()}
 </div>
+%endif
 
 <div class="list_button">
     %if can.milestone.create():
@@ -46,8 +47,6 @@ ${tiles.milestone.timeline(c.milestones)}
       href="${h.base_url('/milestone/new')}">${_("new milestone")}</a>
     %endif
 </div>
-%endif
-
 
 <%components:tutorial>
 <ol id="joyRideTipContent">


### PR DESCRIPTION
Currently a the "new milestone" button at the bottom of the milestone index page is only shown if `c.show_past_milestones` is `True`. I guess this was due to wrong placing of `%endif` but to be sure I created this pull request.
