### PR TITLE
massmessage sort instance list

### DIFF
--- a/src/adhocracy/controllers/massmessage.py
+++ b/src/adhocracy/controllers/massmessage.py
@@ -109,10 +109,11 @@ class MassmessageController(BaseController):
             return Instance.all()
         else:
             perm = Permission.find('instance.message')
-            return [m.instance for m in user.memberships
-                    if (m.instance is not None
-                        and m.instance.is_authenticated
-                        and perm in m.group.permissions)]
+            instances =  [m.instance for m in user.memberships
+                          if (m.instance is not None
+                              and m.instance.is_authenticated
+                              and perm in m.group.permissions)]
+            return sorted(instances, key=lambda i: i.label)
 
     @classmethod
     def _get_allowed_sender_options(cls, user):

--- a/src/adhocracy/model/instance.py
+++ b/src/adhocracy/model/instance.py
@@ -211,6 +211,7 @@ class Instance(meta.Indexable):
                              Instance.hidden == False))
         if limit is not None:
             q = q.limit(limit)
+        q = q.order_by(Instance.label)
         return q.all()
 
     @classmethod


### PR DESCRIPTION
If there are many instances it is quite hard to find one in the massmessage dialog. To make it a bit easier this sorts them alphabetically.

Please note that I added sorting in `model.instance.all()` as this was simplest and I figured it may be useful in other places as well.
