### PR TITLE
fix openlayers bubbles

### DIFF
--- a/src/adhocracy/static_src/stylesheets/general/_misc.scss
+++ b/src/adhocracy/static_src/stylesheets/general/_misc.scss
@@ -119,8 +119,11 @@ iframe {
 
 .staticpage_edit {float: right;}
 
-/* Images should never be bigger than their surrounding element */
-
-img {
-    max-width: 100%;
+/* Images in user generated contend should never be bigger than their surrounding element */
+.comment .body,
+.proposal .body,
+section.subpage {
+    img {
+        max-width: 100%;
+    }
 }


### PR DESCRIPTION
We introduced `max-width: 100%` for all img elements for a reason.
Unfortunately, openlayers does some hacks to display its bubbles.

So this tries to stick to the `max-width: 100%` while keeping
the open layers bubbles (and possibly other hacks of that sort)
intact.

Openlayers bubbles with `max-wdith: 100%`:
![bug](https://f.cloud.github.com/assets/202576/1639625/30884c3e-5825-11e3-977c-b373869ff002.jpg)

And without:
![no-bug](https://f.cloud.github.com/assets/202576/1639626/32c1df88-5825-11e3-8939-fbbba8446981.jpg)
