### PR TITLE
Add watch button to instance overview (fixes #655)

### DIFF
--- a/src/adhocracy/lib/install.py
+++ b/src/adhocracy/lib/install.py
@@ -138,6 +138,7 @@ def setup_entities(config, initial_setup):
         u'vote.prohibit': [organization],
         u'watch.create': [observer, default],
         u'watch.delete': [observer],
+        u'watch.instance': [moderator],
         u'watch.show': [anonymous],
     }
 

--- a/src/adhocracy/templates/instance/show.html
+++ b/src/adhocracy/templates/instance/show.html
@@ -70,7 +70,10 @@ ${c.events_pager.here()}
 </%block>
 
 <%block name="sidebar">
+%if h.has_permission("watch.instance"):
 ${components.watch(c.instance)}
+%endif
+
 %for type in h.config.get_list('adhocracy.instance_overview_sidebar_contents'):
 <div class="sidebar_box">
     %if type == u'events':


### PR DESCRIPTION
As watching an instance results in quite a few notifications being generated, a new permission `watch.instance` is created, which is only assigned to moderators and higher by default.
