### PR TITLE
Disallow milestones without date (fixes #656)

### DIFF
--- a/src/adhocracy/controllers/milestone.py
+++ b/src/adhocracy/controllers/milestone.py
@@ -35,7 +35,7 @@ class MilestoneCreateForm(MilestoneNewForm):
     category = forms.ValidCategoryBadge(if_missing=None, if_empty=None)
     show_all_proposals = validators.StringBool(not_empty=False, if_empty=False,
                                                if_missing=False)
-    time = forms.ValidDate()
+    time = forms.ValidDate(not_empty=True)
     watch = validators.StringBool(not_empty=False, if_empty=False,
                                   if_missing=False)
 
@@ -50,7 +50,7 @@ class MilestoneUpdateForm(MilestoneEditForm):
     category = forms.ValidCategoryBadge(if_missing=None, if_empty=None)
     show_all_proposals = validators.StringBool(not_empty=False, if_empty=False,
                                                if_missing=False)
-    time = forms.ValidDate()
+    time = forms.ValidDate(not_empty=True)
     watch = validators.StringBool(not_empty=False, if_empty=False,
                                   if_missing=False)
 

--- a/src/adhocracy/migration/versions/079_enforce_milestone_date.py
+++ b/src/adhocracy/migration/versions/079_enforce_milestone_date.py
@@ -1,0 +1,17 @@
+from sqlalchemy import MetaData, Table
+
+metadata = MetaData()
+
+
+def upgrade(migrate_engine):
+    metadata.bind = migrate_engine
+
+    table = Table('milestone', metadata, autoload=True)
+    update = table.delete().where(table.c.time == None)  # noqa
+    migrate_engine.execute(update)
+
+    table.c.time.alter(nullable=False)
+
+
+def downgrade(migrate_engine):
+    raise NotImplementedError()

--- a/src/adhocracy/model/milestone.py
+++ b/src/adhocracy/model/milestone.py
@@ -16,7 +16,7 @@ milestone_table = Table(
     Column('category_id', Integer, ForeignKey('badge.id'), nullable=True),
     Column('title', Unicode(255), nullable=True),
     Column('text', UnicodeText(), nullable=True),
-    Column('time', DateTime),
+    Column('time', DateTime, nullable=False),
     Column('create_time', DateTime, default=datetime.utcnow),
     Column('modify_time', DateTime, nullable=True, onupdate=datetime.utcnow),
     Column('delete_time', DateTime),


### PR DESCRIPTION
- Add validator assuring milestones have an assigned date
- Disallow NULL in milestone database model
- Add migration enforcing NOT NULL by deleting milestones without date
