### PR TITLE
treat .paper_text as user generated content

### DIFF
--- a/src/adhocracy/static_src/stylesheets/components/_type.scss
+++ b/src/adhocracy/static_src/stylesheets/components/_type.scss
@@ -41,6 +41,7 @@ blockquote,
         font-size: 1.1em;
     }
 }
+.paper_text,
 .proposal .body {
     h1, h2, h3, h4, h5, h6 {
         font-size: 1em;

--- a/src/adhocracy/static_src/stylesheets/general/_misc.scss
+++ b/src/adhocracy/static_src/stylesheets/general/_misc.scss
@@ -121,6 +121,7 @@ iframe {
 
 /* Images in user generated contend should never be bigger than their surrounding element */
 .comment .body,
+.paper_text,
 .proposal .body,
 section.subpage {
     img {


### PR DESCRIPTION
We apply some special css to user generated content:
-   `img {max-width: 100%}`
-   smaller headings

`.paper_text` was not interpreted as user generated content resulting in issues like this one: 
![treat-papertext-as-ugc](https://f.cloud.github.com/assets/202576/1666634/f4e41e5a-5c49-11e3-8d91-af4e0d595cd8.png)

This fixes the problem by adding `.paper_text` to the list of user genrerated content elements treating it just as `.proposal .body`.
