### PR TITLE
#654 - fix the showing of static pages with underscore

### DIFF
--- a/src/adhocracy/config/routing.py
+++ b/src/adhocracy/config/routing.py
@@ -468,19 +468,22 @@ def make_map(config):
     map.connect('/admin/treatment/{key}/assigned',
                 controller='treatment', action='assigned')
 
+    # TODO - fix these actions: index, make_new, edit, update;
+    #        choose different URLs for edit, update
     map.connect('/static{.format}', controller='static', action='index',
                 conditions=dict(method=['GET', 'HEAD']))
     map.connect('/static{.format}', controller='static', action='make_new',
                 conditions=dict(method=['POST']))
     map.connect('/static/new{.format}', controller='static', action='new')
+    map.connect('/static/{key}{.format}', controller='static',
+                action='serve')
     map.connect('/static/{key}_{lang}',
                 controller='static', action='edit',
                 conditions=dict(method=['GET', 'HEAD']))
     map.connect('/static/{key}_{lang}{.format}',
                 controller='static', action='update',
                 conditions=dict(method=['POST']))
-    map.connect('/static/{key}{.format}', controller='static',
-                action='serve')
+
     map.connect('/outgoing_link/{url_enc}', controller='redirect',
                 action='outgoing_link',
                 conditions=dict(method=['GET', 'HEAD']))

--- a/src/adhocracy/controllers/static.py
+++ b/src/adhocracy/controllers/static.py
@@ -36,7 +36,7 @@ class NewForm(EditForm):
 class StaticController(BaseController):
 
     @guard_perms
-    def index(self):
+    def index(self, format=u'html'):
         data = {
             'static_pages': get_backend().all()
         }
@@ -55,7 +55,7 @@ class StaticController(BaseController):
 
     @guard_perms
     @csrf.RequireInternalRequest(methods=['POST'])
-    def make_new(self):
+    def make_new(self, format=u'html'):
         try:
             form_result = NewForm().to_python(request.params)
         except Invalid as i:
@@ -96,7 +96,7 @@ class StaticController(BaseController):
 
     @guard_perms
     @csrf.RequireInternalRequest(methods=['POST'])
-    def update(self, key, lang):
+    def update(self, key, lang, format=u'html'):
         backend = get_backend()
         sp = backend.get(key, lang)
         if not sp:
@@ -114,7 +114,7 @@ class StaticController(BaseController):
         return redirect(helpers.base_url('/static'))
 
     @guard.perm('static.show')
-    def serve(self, key, format='html'):
+    def serve(self, key, format=u'html'):
         page = get_static_page(key)
         if page is None:
             return abort(404, _('The requested page was not found'))


### PR DESCRIPTION
The main fix is in routing.py. I moved '/static/{key}{.format}' up in the list so that the two rules with "_" do not mess it. The actions "edit" and "update" should not rely on underscores to match their URLs. Some other matching should be devised. This should be part of their implementation.

StaticController.serve() is a fix - "http://host/static/about" causes an error without it.
The other changes in StaticController are just for consistency. These methods are not used anyway.
