### PR TITLE
treat instance_description as user generated content

### DIFF
--- a/src/adhocracy/static_src/stylesheets/components/_type.scss
+++ b/src/adhocracy/static_src/stylesheets/components/_type.scss
@@ -41,6 +41,7 @@ blockquote,
         font-size: 1.1em;
     }
 }
+.instance_description,
 .paper_text,
 .proposal .body {
     h1, h2, h3, h4, h5, h6 {

--- a/src/adhocracy/static_src/stylesheets/general/_misc.scss
+++ b/src/adhocracy/static_src/stylesheets/general/_misc.scss
@@ -120,6 +120,7 @@ iframe {
 .staticpage_edit {float: right;}
 
 /* Images in user generated contend should never be bigger than their surrounding element */
+.instance_description,
 .comment .body,
 .paper_text,
 .proposal .body,

--- a/src/adhocracy/templates/instance/show.html
+++ b/src/adhocracy/templates/instance/show.html
@@ -10,7 +10,9 @@
 
 <%block name="main_content">
 
-${c.tile.description|n}
+<div class="instance_description">
+    ${c.tile.description|n}
+</div>
 
 %for type in h.config.get_list('adhocracy.instance_overview_contents'):
 <hr />


### PR DESCRIPTION
similarly to #663 this adds `.instance_description` to the list of user generated content boxes, especially fixing overflowing images.
