### PR TITLE
use text ellipsis

### DIFF
--- a/src/adhocracy/static_src/stylesheets/general/_mixins.scss
+++ b/src/adhocracy/static_src/stylesheets/general/_mixins.scss
@@ -24,6 +24,7 @@
     text-align: center;
     cursor: pointer;
     white-space: nowrap;
+    text-overflow: ellipsis;
     vertical-align: middle;
     border: none;
     &:hover, &:focus {

--- a/src/adhocracy/static_src/stylesheets/widgets/_sidebar.scss
+++ b/src/adhocracy/static_src/stylesheets/widgets/_sidebar.scss
@@ -47,3 +47,8 @@
     list-style-type: none;
     margin-left: 0;
 }
+
+#settings #col3 .well a {
+    text-overflow: ellipsis;
+    overflow: hidden;
+}


### PR DESCRIPTION
This replaces text overflow by ellipsis for buttons and in the settings menu. Text overflow may occur when an element has dynamic content (e.g. a translated string) and a maximum width.

This is only a minimal change. Still I would like to get feedback. I think this is an improvement because text overflow looks broken and therefore should be avoided. Still replacing text overflow by ellipsis removes information. So I am not sure if this is the bast way to do it.

![ellipsis_after1](https://f.cloud.github.com/assets/202576/1796101/64cd641c-6a53-11e3-9127-e32dc3a9c19a.png)
