### PR TITLE
keep query in global search

### DIFF
--- a/src/adhocracy/controllers/search.py
+++ b/src/adhocracy/controllers/search.py
@@ -33,9 +33,9 @@ class SearchController(BaseController):
     def query(self, format=u'html'):
         c.query = self.form_result.get("serp_q", u"*:*")
         self._query_pager()
-        html = render("search/results.html", {'q': c.query, 'serp_q': c.query},
-                      overlay=format == u'overlay')
-        return formencode.htmlfill.render(html)
+        return formencode.htmlfill.render(
+            self._search_form(),
+            defaults={'serp_q': c.query})
 
     @guard.proposal.index()
     @validate(schema=SearchQueryForm(), post_only=False, on_get=True)

--- a/src/adhocracy/templates/search/results.html
+++ b/src/adhocracy/templates/search/results.html
@@ -21,8 +21,7 @@
     <div class="list_filter">
         <form action="?" class="list_form" method="GET" autocomplete="off">
             <input id="serp_q" name="serp_q" class="live_search search_text"
-                    value="${c.serp_q}"
-                    type="text" autofocus="autofocus" />
+                   type="text" autofocus="autofocus" />
             <input type="submit" value="${_('Search')}" class="search_button" />
         </form>
     </div>


### PR DESCRIPTION
When using the global search the query string is currently lost. This fixes that. However, as both the search bar on the top right and the one in the main column are called `serp_q` the query string is now displayed in both of them.
