### PR TITLE
Add extra add buttons for global / instance badges

### DIFF
--- a/src/adhocracy/templates/badge/index.html
+++ b/src/adhocracy/templates/badge/index.html
@@ -18,7 +18,13 @@ ${h.badge.breadcrumbs(None)|n}
 </%def>
 
 
-<%def name="render_tables(badges, type_, groups, table_def)">
+<%def name="render_tables(badges, title, type_, groups, table_def)">
+<h2>${title}
+  %if not c.instance or not h.has_permission('global.admin'):
+  <a class="button_small plus"
+      href="${c.badge_base_url}/${type_}/add${'?global=true' if h.has_permission('global.admin') else ''}">${_("New")}</a>
+  %endif
+</h2>
 %for group in groups:
     <%
     permission = group['permission']
@@ -28,7 +34,9 @@ ${h.badge.breadcrumbs(None)|n}
     %>
     %if h.has_permission(permission) and group_exists:
         %if group['show_label']:
-        <h4>${group['label']}</h4>
+        <h4>${group['label']}
+        <a class="button_small plus"
+            href="${c.badge_base_url}/${type_}/add${'?global=true' if group['global'] else ''}">${_("New")}</a></h4>
         %endif
     %if badge_items:
     ${table_def(badge_items)}
@@ -175,37 +183,18 @@ ${self.badges_listing()}
 
 
 <%def name="badges_listing()">
-<h2>${_("User Badges")}
-    <a class="button_small plus"
-       href="${c.badge_base_url}/user/add">${_("New")}</a>
-</h2>
-${render_tables(c.badges, 'user', c.groups, user_badges_table)}
 
-<h2>${_("Proposal Badges")}
-    <a class="button_small plus"
-       href="${c.badge_base_url}/delegateable/add">${_("New")}</a>
-</h2>
-${render_tables(c.badges, 'delegateable', c.groups, delegateable_badges_table)}
+${render_tables(c.badges, _("User Badges"), 'user', c.groups, user_badges_table)}
 
-<h2>${_("Proposal Category Badges")}
-    <a class="button_small plus"
-       href="${c.badge_base_url}/category/add">${_("New")}</a>
-</h2>
-${render_tables(c.badges, 'category', c.groups, category_badges_table)}
+${render_tables(c.badges, _("Proposal Badges"), 'delegateable', c.groups, delegateable_badges_table)}
+
+${render_tables(c.badges, _("Proposal Category Badges"), 'category', c.groups, category_badges_table)}
 
 %if c.instance and c.instance.allow_thumbnailbadges:
-<h2>${_("Proposal Thumbnail Badges")}
-    <a class="button_small plus"
-       href="${c.badge_base_url}/thumbnail/add">${_("New")}</a>
-</h2>
-${render_tables(c.badges, 'thumbnail', c.groups, thumbnail_badges_table)}
+${render_tables(c.badges, _("Proposal Thumbnail Badges"), 'thumbnail', c.groups, thumbnail_badges_table)}
 %endif
 
 %if can.badge.manage_global():
-<h2>${_("Instance Badges")}
-    <a class="button_small plus"
-       href="${c.badge_base_url}/instance/add">${_("New")}</a>
-</h2>
-${render_tables(c.badges, 'instance', c.groups, instance_badges_table)}
+${render_tables(c.badges, _("Instance Badges"), 'instance', c.groups, instance_badges_table)}
 %endif
 </%def>


### PR DESCRIPTION
As admins often accidently created global instead of instance badges, we
now add extra buttons above the respective badge tables.

This is pretty ugly code, as controllers._available badges and the
corresponding templates would need refactoring which I don't want to do
now.
