### PR TITLE
fix thumbnail badge size

### DIFF
--- a/src/adhocracy/lib/helpers/badge_helper.py
+++ b/src/adhocracy/lib/helpers/badge_helper.py
@@ -18,7 +18,8 @@ def make_key(iden, args, kwargs):
     sig = iden[:200]\
         + cache.util.make_tag(conf("adhocracy.thumbnailbadges.width"))\
         + cache.util.make_tag(conf("adhocracy.thumbnailbadges.height"))\
-        + cache.util.make_tag(instance_w + instance_h)\
+        + cache.util.make_tag(instance_w)\
+        + cache.util.make_tag(instance_h)\
         + cache.util.make_tag(args) \
         + cache.util.make_tag(kwargs)
     return sha1(sig).hexdigest()


### PR DESCRIPTION
the old version gave

  TypeError: cannot concatenate 'str' and 'int' objects

when only one of thumbnail height and width was set on the
instance level.
