### PR TITLE
Do not expose language territory

### DIFF
--- a/src/adhocracy/controllers/instance.py
+++ b/src/adhocracy/controllers/instance.py
@@ -524,7 +524,7 @@ class InstanceController(BaseController):
         c.locales = []
         for locale in i18n.LOCALES:
             c.locales.append({'value': str(locale),
-                              'label': locale.display_name,
+                              'label': locale.language_name,
                               'selected': locale == c.page_instance.locale})
 
         return render("/instance/settings_general.html")

--- a/src/adhocracy/controllers/user.py
+++ b/src/adhocracy/controllers/user.py
@@ -362,7 +362,7 @@ class UserController(BaseController):
         c.locales = []
         for locale in i18n.LOCALES:
             c.locales.append({'value': str(locale),
-                              'label': locale.display_name,
+                              'label': locale.language_name,
                               'selected': locale == c.user.locale})
 
         c.salutations = [

--- a/src/adhocracy/lib/helpers/staticpage_helper.py
+++ b/src/adhocracy/lib/helpers/staticpage_helper.py
@@ -13,7 +13,7 @@ def url(staticpage, **kwargs):
 
 def get_lang_info(lang):
     locale = babel.core.Locale(lang)
-    return {'id': lang, 'name': locale.display_name}
+    return {'id': lang, 'name': locale.language_name}
 
 
 def can_edit():


### PR DESCRIPTION
As we currently don't distinguish anyway between different language
territories, there's no use in exposing the territory through the UI.
