### PR TITLE
fix file upload in overlays

### DIFF
--- a/src/adhocracy/static/javascripts/adhocracy.js
+++ b/src/adhocracy/static/javascripts/adhocracy.js
@@ -1169,4 +1169,11 @@ $(document).ready(function () {
         this.type = 'submit';
         this.click();
     });
+
+    // check if FormData is available and add class to html element
+    if ("FormData" in window) {
+        $('.only-no-formdata').remove();
+    } else {
+        $('html').addClass('no-formdata');
+    }
 });

--- a/src/adhocracy/static_src/stylesheets/components/_forms.scss
+++ b/src/adhocracy/static_src/stylesheets/components/_forms.scss
@@ -247,3 +247,10 @@ fieldset.logo {
         text-align: center;
     }
 }
+
+.only-no-formdata {
+    display: none;
+}
+.overlay.no-formdata .only-no-formdata {
+    display: block;
+}

--- a/src/adhocracy/templates/badge/form.html
+++ b/src/adhocracy/templates/badge/form.html
@@ -57,6 +57,9 @@ ${self.form()}
 
     %if c.badge_type == 'thumbnail' or (c.badge_type == 'category' and c.instance is not None and c.instance.display_category_pages):
     <fieldset class="logo">
+        <div class="alert error only-no-formdata">
+            ${_('Image upload does not work in your browser. Please update.')}
+        </div>
         <%
             if c.badge_type == 'thumbnail':
                 label = _('Image')


### PR DESCRIPTION
To include files in our upload this uses the FormData API.

Unfortunately, FormData is only available in IE 10+. In older IEs, the whole form will be unusable.

To limit the damage this does only use FormData where necessary.

This was meant to be a fix for #724 but with the limitations mentioned above I am not sure if this counts as one.
