### PR TITLE
rm js tooltips (fixes #208)

### DIFF
--- a/src/adhocracy/static/javascripts/adhocracy.js
+++ b/src/adhocracy/static/javascripts/adhocracy.js
@@ -417,31 +417,6 @@ var adhocracy = adhocracy || {};
     };
 
     /***************************************************
-     * @namespace: adhocracy.tooltips
-     ***************************************************/
-
-    adhocracy.namespace('adhocracy.tooltips');
-
-    /**
-     * Initialize the tooltips for all correctly marked
-     * elements found inside baseSelector. If baseSelector
-     * is not given, it searches for all elements in the
-     * document body.
-     *
-     * @param {string} baseSelector A selector string that can be
-     * passed to jQuery. Optional, defaults to 'body'.
-     */
-    adhocracy.tooltips.initialize = function (baseSelector) {
-        baseSelector = baseSelector || 'body';
-        $(baseSelector).find(".ttip[title]").tooltip({
-            position: "bottom left",
-            opacity: 1,
-            effect: 'toggle'
-        }).dynamic({ bottom: { direction: 'down', bounce: true } });
-    };
-
-
-    /***************************************************
      * @namespace: adhocracy.helpers
      ***************************************************/
 
@@ -702,7 +677,6 @@ $(document).ready(function () {
     // initial jquery elastic
     $('textarea').elastic();
 
-    adhocracy.tooltips.initialize();
     adhocracy.helpers.initializeFlashMessageDelegates();
     adhocracy.helpers.initializeTagsAutocomplete('#tags');
     adhocracy.helpers.initializeUserAutocomplete(".userCompleted");

--- a/src/adhocracy/static_src/stylesheets/adhocracy.scss
+++ b/src/adhocracy/static_src/stylesheets/adhocracy.scss
@@ -25,7 +25,6 @@
 @import "components/morelink";
 @import "components/showmore";
 @import "components/bootstrap_nav";
-@import "components/tooltip";
 @import "components/badge";
 @import "components/button";
 @import "components/modals";

--- a/src/adhocracy/static_src/stylesheets/components/_tooltip.scss
+++ b/src/adhocracy/static_src/stylesheets/components/_tooltip.scss
@@ -1,9 +1,0 @@
-.tooltip {
-    display:none;
-    background: $flash;
-    text-align: left;
-    line-height: 1.3;
-    color: $black;
-    border: 1px solid $border;
-    padding: 0.5em 1em;
-}


### PR DESCRIPTION
The JavaScript tooltips we are using are buggy.

I see no real reason why we use the in the first place
because the tooltip implementation in browsers is quite good
and probably has benefits in terms of accessibility, too.

So this removes the js tooltips.
