### PR TITLE
Fix URL validation

### DIFF
--- a/docs/development/use_cases/admin_user_import.rst
+++ b/docs/development/use_cases/admin_user_import.rst
@@ -36,4 +36,4 @@ Anonymous users cannot open the form:
     >>> anon.raiseHttpErrors = False
     >>> anon.open('http://test.lan/admin/users/import')
     >>> anon.url
-    'http://test.lan/login?ret_url=http%3A%2F%2Ftest.lan%2Fadmin%2Fusers%2Fimport'
+    'http://test.lan/login?came_from=http%3A%2F%2Ftest.lan%2Fadmin%2Fusers%2Fimport'

--- a/docs/development/use_cases/shibboleth_authentication.rst
+++ b/docs/development/use_cases/shibboleth_authentication.rst
@@ -74,13 +74,13 @@ form is displayed:
     >>> set_no_redirect(browser)
 
 FIXME: check whether ANY_URL should be encoded
-    >>> browser.open(REQUEST_AUTH_URL + '?ret_url=' + ANY_URL)
+    >>> browser.open(REQUEST_AUTH_URL + '?came_from=' + ANY_URL)
     >>> browser.headers['status']
     '302 Found'
     >>> browser.headers['location']
-    'http://test.lan/Shibboleth.sso/Login?target=%2Fshibboleth%2Fpost_auth%3Fret_url%3Dhttp%253A%252F%252Ftest.lan%252Finstance'
+    'http://test.lan/Shibboleth.sso/Login?target=%2Fshibboleth%2Fpost_auth%3Fcame_from%3Dhttp%253A%252F%252Ftest.lan%252Finstance'
 
-    >>> browser.open(POST_AUTH_URL + '?ret_url=' + ANY_URL)
+    >>> browser.open(POST_AUTH_URL + '?came_from=' + ANY_URL)
 
     >>> form = browser.getForm(name='complete_registration')
     >>> username = form.getControl(name='username')
@@ -142,7 +142,7 @@ Hugo has lost his `editor` status. Make sure the model is updated.
     >>> browser2 = make_browser()
     >>> set_no_redirect(browser2)
     >>> add_headers(browser2, new_hugo_headers)
-    >>> browser2.open(POST_AUTH_URL + '?ret_url=' + ANY_URL)
+    >>> browser2.open(POST_AUTH_URL + '?came_from=' + ANY_URL)
     >>> browser2.open(ANY_URL)
     >>> is_logged_in(browser2)
     True

--- a/etc/adhocracy.ini.in
+++ b/etc/adhocracy.ini.in
@@ -319,7 +319,7 @@ piwik.id =
 # INSTALL: Allow users to lock themselves out of adhocracy
 # adhocracy.self_deletion_allowed = true
 
-# In the case that no ret_url parameter is set, users are redirected to the
+# In the case that no came_from parameter is set, users are redirected to the
 # locations defined in the following settings. You can leave any of these
 # commented out. If instance is given, the url of the given instance is used
 # to build the URL, otherwise the current instance is used.

--- a/src/adhocracy/controllers/comment.py
+++ b/src/adhocracy/controllers/comment.py
@@ -136,8 +136,8 @@ class CommentController(BaseController):
         event.emit(event.T_COMMENT_CREATE, c.user, instance=c.instance,
                    topics=[topic], comment=comment, topic=topic,
                    rev=comment.latest)
-        if c.ret_url != u'':
-            redirect(c.ret_url + "#c" + str(comment.id))
+        if c.came_from != u'':
+            redirect(c.came_from + "#c" + str(comment.id))
         if format != 'html':
             return ret_success(entity=comment, format=format)
         else:
@@ -148,8 +148,8 @@ class CommentController(BaseController):
         c.comment = get_entity_or_abort(model.Comment, id)
         require.comment.edit(c.comment)
         extra_vars = {'comment': c.comment}
-        if c.ret_url != u'':
-            extra_vars[u'ret_url'] = c.ret_url
+        if c.came_from != u'':
+            extra_vars[u'came_from'] = c.came_from
         if format == 'ajax':
             return render_def('/comment/tiles.html', 'edit_form',
                               extra_vars=extra_vars)
@@ -180,8 +180,8 @@ class CommentController(BaseController):
         event.emit(event.T_COMMENT_EDIT, c.user, instance=c.instance,
                    topics=[c.comment.topic], comment=c.comment,
                    topic=c.comment.topic, rev=rev)
-        if c.ret_url != u'':
-            redirect(c.ret_url + "#c" + str(c.comment.id))
+        if c.came_from != u'':
+            redirect(c.came_from + "#c" + str(c.comment.id))
         if format != 'html':
             return ret_success(entity=c.comment, format=format)
         else:
@@ -292,13 +292,13 @@ class CommentController(BaseController):
                              code=400)
         return self._render_ajax_create_form(None, topic, variant)
 
-    def _render_ajax_create_form(self, parent, topic, variant, ret_url=None):
+    def _render_ajax_create_form(self, parent, topic, variant, came_from=None):
         '''
         render a create form fragment that can be inserted loaded
         into another page.
         '''
-        if ret_url is None:
-            ret_url = ''
+        if came_from is None:
+            came_from = ''
 
         # FIXME: uncomment the format parameter when we have javascript
         # code to submit the form with ajax and replace the form with the
@@ -309,7 +309,7 @@ class CommentController(BaseController):
                              topic=topic,
                              variant=variant,
                              #format="ajax",
-                             ret_url=ret_url,
+                             came_from=came_from,
                              )
         return render_def('/comment/tiles.html', 'create_form',
                           extra_vars=template_args)
@@ -319,5 +319,5 @@ class CommentController(BaseController):
         require.comment.reply(parent)
         topic = parent.topic
         variant = getattr(topic, 'variant', None)
-        ret_url = c.ret_url
-        return self._render_ajax_create_form(parent, topic, variant, ret_url)
+        came_from = c.came_from
+        return self._render_ajax_create_form(parent, topic, variant, came_from)

--- a/src/adhocracy/controllers/instance.py
+++ b/src/adhocracy/controllers/instance.py
@@ -977,7 +977,7 @@ class InstanceController(BaseController):
                                'instance': c.page_instance.label
                            },
                            category='success',
-                           force_path=c.ret_url)
+                           force_path=c.came_from)
 
     def ask_leave(self, id):
         c.page_instance = self._get_current_instance(id)

--- a/src/adhocracy/controllers/page.py
+++ b/src/adhocracy/controllers/page.py
@@ -213,15 +213,15 @@ class PageController(BaseController):
         if self.form_result.get("parent") is not None:
             page.parents.append(self.form_result.get("parent"))
 
-        if c.ret_url != u'':
-            ret_url = c.ret_url
+        if c.came_from != u'':
+            came_from = c.came_from
         elif proposal is not None and can.selection.create(proposal):
             model.Selection.create(proposal, page, c.user, variant=variant)
             # if a selection was created, go there instead:
-            ret_url = h.page.url(page, member='branch',
+            came_from = h.page.url(page, member='branch',
                                  query={'proposal': proposal.id})
         else:
-            ret_url = h.entity_url(page)  # by default, redirect to the page
+            came_from = h.entity_url(page)  # by default, redirect to the page
 
         categories = self.form_result.get('category')
         category = categories[0] if categories else None
@@ -232,7 +232,7 @@ class PageController(BaseController):
             watchlist.set_watch(page, self.form_result.get('watch'))
         event.emit(event.T_PAGE_CREATE, c.user, instance=c.instance,
                    topics=[page], page=page, rev=page.head)
-        redirect(ret_url)
+        redirect(came_from)
 
     @RequireInstance
     @validate(schema=PageEditForm(), form='edit', post_only=False, on_get=True)
@@ -273,12 +273,12 @@ class PageController(BaseController):
         if branch and c.text is None:
             c.text = c.page.head.text
 
-        if c.ret_url != u'':
-            c.ret_url = c.ret_url
+        if c.came_from != u'':
+            c.came_from = c.came_from
         elif c.section:
-            c.ret_url = h.entity_url(c.parent, anchor="subpage-%i" % c.page.id)
+            c.came_from = h.entity_url(c.parent, anchor="subpage-%i" % c.page.id)
         else:
-            c.ret_url = h.entity_url(c.text)
+            c.came_from = h.entity_url(c.text)
 
         c.text_rows = libtext.text_rows(c.text)
         c.left = c.page.head
@@ -369,8 +369,8 @@ class PageController(BaseController):
             watchlist.set_watch(c.page, self.form_result.get('watch'))
         event.emit(event.T_PAGE_EDIT, c.user, instance=c.instance,
                    topics=[c.page], page=c.page, rev=text)
-        if c.ret_url != u'':
-            redirect(c.ret_url)
+        if c.came_from != u'':
+            redirect(c.came_from)
         else:
             redirect(h.entity_url(text))
 
@@ -665,12 +665,12 @@ class PageController(BaseController):
             h.flash(_("No such text revision."), 'notice')
             redirect(h.entity_url(c.page))
         self._common_metadata(c.page, c.text)
-        c.ret_url = ''
+        c.came_from = ''
 
         if format == 'ajax':
             return tiles.comment.list(c.page)
         elif format == 'overlay':
-            c.ret_url = h.entity_url(c.page, member='comments') + '.overlay'
+            c.came_from = h.entity_url(c.page, member='comments') + '.overlay'
             return render('/page/comments.html', overlay=True)
         else:
             return render('/page/comments.html')
@@ -751,9 +751,9 @@ class PageController(BaseController):
         if c.section:
             c.parent = get_entity_or_abort(
                 model.Page, request.params.get(u'section_parent'))
-            c.ret_url = h.entity_url(c.parent)
+            c.came_from = h.entity_url(c.parent)
         else:
-            c.ret_url = h.entity_url(c.page.instance)
+            c.came_from = h.entity_url(c.page.instance)
 
         return render("/page/ask_delete.html", overlay=(format == u'overlay'))
 
@@ -768,7 +768,7 @@ class PageController(BaseController):
                    topics=[c.page], page=c.page)
         h.flash(_("The page %s has been deleted.") % c.page.title,
                 'success')
-        redirect(c.ret_url)
+        redirect(c.came_from)
 
     def _get_page_and_text(self, id, variant, text):
         page = get_entity_or_abort(model.Page, id)

--- a/src/adhocracy/controllers/proposal.py
+++ b/src/adhocracy/controllers/proposal.py
@@ -529,21 +529,21 @@ class ProposalController(BaseController):
         c.proposal = get_entity_or_abort(model.Proposal, id)
         require.proposal.delete(c.proposal)
         if c.proposal.is_amendment:
-            ret_url = h.entity_url(c.proposal.selection.page,
-                                   member='amendment')
+            came_from = h.entity_url(c.proposal.selection.page,
+                                     member='amendment')
             page = c.proposal.selection.page
             event.emit(event.T_AMENDMENT_DELETE, c.user, instance=c.instance,
                        topics=[c.proposal, page], proposal=c.proposal,
                        page=page)
         else:
-            ret_url = h.entity_url(c.instance)
+            came_from = h.entity_url(c.instance)
             event.emit(event.T_PROPOSAL_DELETE, c.user, instance=c.instance,
                        topics=[c.proposal], proposal=c.proposal)
         c.proposal.delete()
         model.meta.Session.commit()
         h.flash(_("The proposal %s has been deleted.") % c.proposal.title,
                 'success')
-        redirect(ret_url)
+        redirect(came_from)
 
     @RequireInstance
     def ask_adopt(self, id):

--- a/src/adhocracy/controllers/shibboleth.py
+++ b/src/adhocracy/controllers/shibboleth.py
@@ -49,11 +49,11 @@ class ShibbolethController(BaseController):
         if not 'shibboleth' in allowed_login_types():
             ret_abort(_("Shibboleth authentication not enabled"), code=403)
 
-        ret_url = request.GET.get('ret_url', '/')
+        came_from = request.GET.get('came_from', '/')
 
-        ret_url_qs = urlencode({'ret_url': ret_url})
+        came_from_qs = urlencode({'came_from': came_from})
         shib_qs = urlencode(
-            {'target': '/shibboleth/post_auth?%s' % ret_url_qs})
+            {'target': '/shibboleth/post_auth?%s' % came_from_qs})
 
         redirect('/Shibboleth.sso/Login?%s' % shib_qs)
 
@@ -104,8 +104,8 @@ class ShibbolethController(BaseController):
         login_user(user, request, response)
         session['login_type'] = 'shibboleth'
 
-        ret_url = request.GET.get('ret_url', target)
-        qs = urlencode({'return': ret_url})
+        came_from = request.GET.get('came_from', target)
+        qs = urlencode({'return': came_from})
 
         return redirect('/Shibboleth.sso/Logout?%s' % qs)
 

--- a/src/adhocracy/controllers/user.py
+++ b/src/adhocracy/controllers/user.py
@@ -293,8 +293,8 @@ class UserController(BaseController):
         if authenticated:
             session['logged_in'] = True
             session.save()
-            if c.ret_url != u'':
-                location = urllib.unquote_plus(c.ret_url)
+            if c.came_from != u'':
+                location = urllib.unquote_plus(c.came_from)
             else:
                 location = h.user.post_register_url(user)
             raise HTTPFound(location=location, headers=headers)
@@ -765,7 +765,7 @@ class UserController(BaseController):
             message=_("The activation link has been re-sent to your email "
                       "address."), category='success',
             entity=c.page_user, member='settings/notifications',
-            format=None, force_path=c.ret_url)
+            format=None, force_path=c.came_from)
 
     @staticmethod
     def _get_profile_nav(user, active_key):
@@ -909,7 +909,7 @@ class UserController(BaseController):
     def dashboard(self, format='html', current_nav=u'all', event_filter=[]):
         if c.user is None:
             redirect(h.base_url('/login', query_params={
-                u'ret_url': request.url,
+                u'came_from': request.url,
             }))
 
         require.user.show_dashboard(c.user)
@@ -998,8 +998,8 @@ class UserController(BaseController):
     def login(self):
         c.active_global_nav = "login"
         if c.user:
-            if c.ret_url != u'':
-                redirect(urllib.unquote_plus(c.ret_url))
+            if c.came_from != u'':
+                redirect(urllib.unquote_plus(c.came_from))
             else:
                 redirect(h.user.post_login_url(c.user))
         else:
@@ -1032,8 +1032,8 @@ class UserController(BaseController):
         if c.user:
             session['logged_in'] = True
             session.save()
-            if c.ret_url != u'':
-                redirect(urllib.unquote_plus(c.ret_url))
+            if c.came_from != u'':
+                redirect(urllib.unquote_plus(c.came_from))
             else:
                 # redirect to the dashboard inside the instance exceptionally
                 # to be able to link to proposals and norms in the welcome
@@ -1417,7 +1417,7 @@ class UserController(BaseController):
     def welcome(self, id, token):
         # Intercepted by WelcomeRepozeWho, only errors go in here
         if c.user:
-            return redirect(request.params.get('ret_url', '/'))
+            return redirect(request.params.get('came_from', '/'))
 
         h.flash(_('You already have a password - use that to log in.'),
                 'error')

--- a/src/adhocracy/lib/auth/welcome.py
+++ b/src/adhocracy/lib/auth/welcome.py
@@ -64,8 +64,8 @@ class WelcomeRepozeWho(object):
             return None
 
         qs = urlparse.parse_qs(environ['QUERY_STRING'])
-        if 'ret_url' in qs and h.site.is_local_url(qs['ret_url'][0]):
-            redirect_url = qs['ret_url'][0]
+        if 'came_from' in qs and h.site.is_local_url(qs['came_from'][0]):
+            redirect_url = qs['came_from'][0]
         else:
             from adhocracy.lib.helpers import base_url
             redirect_url = base_url('/', instance=None, config=self.config)

--- a/src/adhocracy/lib/base.py
+++ b/src/adhocracy/lib/base.py
@@ -43,8 +43,8 @@ class BaseController(WSGIController):
         c.debug = config.get_bool('debug')
         i18n.handle_request()
 
-        if h.site.is_local_url(request.params.get(u'ret_url', u'')):
-            c.ret_url = request.params.get(u'ret_url', u'')
+        if h.site.is_local_url(request.params.get(u'came_from', u'')):
+            c.came_from = request.params.get(u'came_from', u'')
 
         monitor_page_time_interval = config.get_int(
             'adhocracy.monitor_page_time_interval', -1)

--- a/src/adhocracy/lib/helpers/__init__.py
+++ b/src/adhocracy/lib/helpers/__init__.py
@@ -182,21 +182,21 @@ def help_link(text, page, anchor=None):
 
 def get_redirect_url(target=u'login', entity=None, **kwargs):
     '''
-    Builds an URL similar to  ".../login?ret_url=http...." pointing to the
+    Builds an URL similar to  ".../login?came_from=http...." pointing to the
     target path in the current instance domain. If we already have a
-    ``ret_url`` parameter in the path, this is going to be used as the new
-    ``ret_url`` target. Otherwise, if ``entity`` is set, this will redirect
+    ``came_from`` parameter in the path, this is going to be used as the new
+    ``came_from`` target. Otherwise, if ``entity`` is set, this will redirect
     to the given entity after successful login. If ``entity`` is None, it will
     redirect to the current URL.
     '''
-    if c.ret_url == u'':
+    if c.came_from == u'':
         if entity is None:
-            c.ret_url = base_url(request.path,
+            c.came_from = base_url(request.path,
                                  query_string=request.query_string)
         else:
-            c.ret_url = entity_url(entity, **kwargs)
+            c.came_from = entity_url(entity, **kwargs)
 
-    return build(c.instance, '', target, query={'ret_url': c.ret_url})
+    return build(c.instance, '', target, query={'came_from': c.came_from})
 
 
 def login_redirect_url(entity=None, **kwargs):

--- a/src/adhocracy/lib/tiles/comment_tiles.py
+++ b/src/adhocracy/lib/tiles/comment_tiles.py
@@ -60,20 +60,20 @@ def header(comment, tile=None, active='comment'):
 
 
 def list(topic, root=None, comments=None, variant=None, recurse=True,
-         ret_url=''):
+         came_from=''):
     cached = c.user is None
     if comments is None:
         comments = topic.comments
     return render_tile('/comment/tiles.html', 'list', tile=None,
                        comments=comments, topic=topic,
                        variant=variant, root=root, recurse=recurse,
-                       cached=cached, ret_url=ret_url)
+                       cached=cached, came_from=came_from)
 
 
-def show(comment, recurse=True, ret_url=''):
+def show(comment, recurse=True, came_from=''):
     can_edit = can.comment.edit(comment)
     groups = sorted(c.user.groups if c.user else [])
     return render_tile('/comment/tiles.html', 'show', CommentTile(comment),
                        comment=comment, cached=True, can_edit=can_edit,
-                       groups=groups, ret_url=ret_url, recurse=recurse,
+                       groups=groups, came_from=came_from, recurse=recurse,
                        cache_csrf_token=token_id())

--- a/src/adhocracy/static/javascripts/adhocracy.js
+++ b/src/adhocracy/static/javascripts/adhocracy.js
@@ -157,7 +157,7 @@ var adhocracy = adhocracy || {};
          *
          *    Form actions are not rewritten. Instead, possible
          *    error or success messages are loaded inside the overlay.
-         *    You should set a sensible `ret_url` for forms in overlays.
+         *    You should set a sensible `came_from` for forms in overlays.
          *
          * This mechanism is powerful because it allows to load
          * any page inside an overlay and most things just work.
@@ -286,15 +286,15 @@ var adhocracy = adhocracy || {};
     };
 
     adhocracy.overlay.rebindRetURL = function () {
-        var ret_url = this.getTrigger().attr('href');
-        if (ret_url === undefined) {
-            ret_url = window.location.pathname;
+        var came_from = this.getTrigger().attr('href');
+        if (came_from === undefined) {
+            came_from = window.location.pathname;
         }
         var patch_returl = function (i, val) {
             if (val === undefined) {
                 return undefined;
             }
-            return new Uri(val).replaceQueryParam('ret_url', ret_url).toString();
+            return new Uri(val).replaceQueryParam('came_from', came_from).toString();
         };
         this.getOverlay().find('.patch_returl').attr({
             'action': patch_returl,

--- a/src/adhocracy/templates/admin/userimport_form.html
+++ b/src/adhocracy/templates/admin/userimport_form.html
@@ -11,7 +11,7 @@
 ${self.form()}
 </%block>
 
-<%def name="form(ret_url='')">
+<%def name="form(came_from='')">
 
 <form name="import_users" class="well" method="POST">
 
@@ -70,6 +70,6 @@ ${self.form()}
            </%def>
         </%forms:textarea>
     </div>
-    ${components.savebox(ret_url)}
+    ${components.savebox(came_from)}
 </form>
 </%def>

--- a/src/adhocracy/templates/comment/edit.html
+++ b/src/adhocracy/templates/comment/edit.html
@@ -16,5 +16,5 @@
         ${tiles.comment.show(c.comment.reply, recurse=False)}
     %endif
 
-    ${t.edit_form(c.comment, ret_url=c.ret_url)}
+    ${t.edit_form(c.comment, came_from=c.came_from)}
 </%block>

--- a/src/adhocracy/templates/comment/tiles.html
+++ b/src/adhocracy/templates/comment/tiles.html
@@ -19,7 +19,7 @@
 </%def>
 
 
-<%def name="list(tile, comments, topic, variant=None, root=None, recurse=True, ret_url='')">
+<%def name="list(tile, comments, topic, variant=None, root=None, recurse=True, came_from='')">
     <%
     _comments = h.comments_sorted(comments, root=root, variant=variant)
     %>
@@ -41,7 +41,7 @@
              id="${target}"
              data-cancel=".cancel">
             <div class="comment">
-                ${create_form(None, topic, variant=variant, ret_url=ret_url, show_cancel=(len(comments) != 0))}
+                ${create_form(None, topic, variant=variant, came_from=came_from, show_cancel=(len(comments) != 0))}
             </div>
         </div>
         %if hide_form:
@@ -102,10 +102,10 @@
         %for comment, tile in _comments:
         %if tile.show:
         <li>
-            ${tiles.comment.show(comment, recurse=recurse, ret_url=ret_url)}
+            ${tiles.comment.show(comment, recurse=recurse, came_from=came_from)}
 
             %if recurse:
-            ${tiles.comment.list(comment.topic, comment, comment.topic.comments,  variant=variant, recurse=recurse, ret_url=ret_url)}
+            ${tiles.comment.list(comment.topic, comment, comment.topic.comments,  variant=variant, recurse=recurse, came_from=came_from)}
             %endif
 
         </li>
@@ -116,7 +116,7 @@
 </%def>
 
 
-<%def name="show(tile, comment, ret_url='')">
+<%def name="show(tile, comment, came_from='')">
     <%
     if not tile.show:
         return
@@ -144,7 +144,7 @@
                     %if can.comment.edit(comment):
                     <a class="edit_comment"
                        href="${h.entity_url(comment, member='edit',
-                                            query=dict(ret_url=ret_url))}">
+                                            query=dict(came_from=came_from))}">
                         ${_("edit")}</a>
                     %endif
 
@@ -210,7 +210,7 @@
                 ## Reply button
                 <% auth = check.comment.reply(comment) %>
                 %if auth and recurse:
-                <a class="new_comment" data-reply-url="${h.base_url('/comment/form/reply/' + str(comment.id), query_params={'ret_url': ret_url})}" href="#">${_('reply') if h.comment.wording() else _('Add argument')}</a>
+                <a class="new_comment" data-reply-url="${h.base_url('/comment/form/reply/' + str(comment.id), query_params={'came_from': came_from})}" href="#">${_('reply') if h.comment.wording() else _('Add argument')}</a>
                 %elif auth.propose_join():
                 <a class="new_comment" title="${_('Join instance to reply') if h.comment.wording() else _('Join instance to argue')}" rel="#overlay-join-button">${_('reply') if h.comment.wording() else _('Add argument')}</a>
                 %elif auth.propose_login():
@@ -223,7 +223,7 @@
     </div>
 </%def>
 
-<%def name="edit_form(comment, ret_url='')">
+<%def name="edit_form(comment, came_from='')">
 
 <%
 
@@ -243,7 +243,7 @@ klass_con = klass(-1)
           method="POST" action="${h.entity_url(comment, comment_page=True)}">
         ${h.field_token()|n}
         <input type="hidden" name="_method" value="PUT" />
-        <input type="hidden" name="ret_url" value="${ret_url}" />
+        <input type="hidden" name="came_from" value="${came_from}" />
       <div class="subcolumns">
         <div class="c60l">
           <div class="subcl">
@@ -280,7 +280,7 @@ klass_con = klass(-1)
 </%def>
 
 
-<%def name="create_form(parent, topic, wiki=None, arm=False, can_wiki=True, variant=None, ret_url='', format=None, show_cancel=True)">
+<%def name="create_form(parent, topic, wiki=None, arm=False, can_wiki=True, variant=None, came_from='', format=None, show_cancel=True)">
 
 <%
 if format is None:
@@ -295,7 +295,7 @@ if wiki is None:
         method="POST" action="${h.base_url('/comment%s' % format, topic.instance)}">
       ${h.field_token()|n}
       <input type="hidden" name="topic" value="${topic.id}" />
-      <input type="hidden" name="ret_url" value="${ret_url}" />
+      <input type="hidden" name="came_from" value="${came_from}" />
       %if variant:
           <input type="hidden" name="variant" value="${variant}" />
       %endif

--- a/src/adhocracy/templates/page/ask_delete.html
+++ b/src/adhocracy/templates/page/ask_delete.html
@@ -13,7 +13,7 @@
     action="${h.entity_url(c.page, in_context=False)}">
     ${h.field_token()|n}
     <input type="hidden" name="_method" value="DELETE" />
-    <input type="hidden" name="ret_url" value="${c.ret_url}"/>
+    <input type="hidden" name="came_from" value="${c.came_from}"/>
     <div class="sidebar">
         &nbsp;
     </div>

--- a/src/adhocracy/templates/page/comments.html
+++ b/src/adhocracy/templates/page/comments.html
@@ -1,5 +1,5 @@
 <%inherit file="/template.html" />
 
 <%block name="main_content">
-    ${tiles.comment.list(c.page, ret_url=c.ret_url)}
+    ${tiles.comment.list(c.page, came_from=c.came_from)}
 </%block>

--- a/src/adhocracy/templates/page/edit.html
+++ b/src/adhocracy/templates/page/edit.html
@@ -33,7 +33,7 @@
     %endif
 
     <input type="hidden" name="_method" value="PUT" />
-    <input type="hidden" name="ret_url" value="${c.ret_url}" />
+    <input type="hidden" name="came_from" value="${c.came_from}" />
 
     <label for="text">${_("Text")}</label>
     <textarea rows="${c.text_rows}"
@@ -111,7 +111,7 @@
     ${tiles.milestone.select(c.page.milestone)}
     %endif
 
-    ${components.savebox(c.ret_url)}
+    ${components.savebox(c.came_from)}
     ${components.form_watch(c.page)}
 
 </form>

--- a/src/adhocracy/templates/page/new.html
+++ b/src/adhocracy/templates/page/new.html
@@ -19,7 +19,7 @@
     %endif
 
     %if c.section:
-    <input type="hidden" name="ret_url" value="${h.entity_url(c.parent)}" />
+    <input type="hidden" name="came_from" value="${h.entity_url(c.parent)}" />
     %endif
 
     <div class="mainbar">

--- a/src/adhocracy/tests/lib/test_url.py
+++ b/src/adhocracy/tests/lib/test_url.py
@@ -83,7 +83,7 @@ class TestUrls(TestController):
 
         proposal = tt_make_proposal(title=u'testproposal')
         url = login_redirect_url(proposal)
-        expected = (u'http://test.test.lan/login?ret_url='
+        expected = (u'http://test.test.lan/login?came_from='
                     u'http%3A%2F%2Ftest.test.lan%2Fproposal%2F2-testproposal')
         self.assertEqual(url, expected)
 


### PR DESCRIPTION
This addresses two issues with validation of URLs given as URL parameters.

On the one hand this does a bit of refactoring concerning `ret_url`/`came_from` (see #574) and provides input validation in a central place. On the other hand this improves the validation used when linking to overlays (see #553/#555).

While the one is implemented in python on the server and the other in JavaScript on the client I tried to make the validators as similar as possible.
