### PR TITLE
fix html escaping in search placeholder text

### DIFF
--- a/src/adhocracy/templates/navigation.html
+++ b/src/adhocracy/templates/navigation.html
@@ -172,11 +172,11 @@
 <%def name="subheader_instance_navigation(active)">
 
 <%
-   import cgi
+   import mako
    from adhocracy.lib.tiles.instance_tiles import InstanceTile
    active_subnav = {}
    active_subnav[active or 'instance'] = 'current'
-   search_label = _('Search in &ldquo;%s&rdquo;&hellip;') % cgi.escape(c.instance.label)
+   search_label = _('Search in &ldquo;%s&rdquo;&hellip;') % mako.filters.html_escape(c.instance.label)
    logo = ''
    url = None
    if c.instance:


### PR DESCRIPTION
This fixes a tiny bug. I would have committed it directly but I understand that 2.1.0 will be released today so I did not want to throw in random stuff so I created this pull request instead.

To reproduce the issue, create an instance with `"` in the title.
