### PR TITLE
pass MetaData to alembic

### DIFF
--- a/src/adhocracy/alembic/env.py
+++ b/src/adhocracy/alembic/env.py
@@ -3,6 +3,8 @@ from alembic import context
 from sqlalchemy import engine_from_config, pool
 from logging.config import fileConfig
 
+from adhocracy.model.meta import data
+
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
 config = context.config
@@ -15,7 +17,7 @@ fileConfig(config.config_file_name)
 # for 'autogenerate' support
 # from myapp import mymodel
 # target_metadata = mymodel.Base.metadata
-target_metadata = None
+target_metadata = data
 
 # other values from the config, defined by the needs of env.py,
 # can be acquired:


### PR DESCRIPTION
this allows to use the autogenerate feature (See http://alembic.readthedocs.org/en/latest/tutorial.html#auto-generating-migrations)
