### PR TITLE
abstract area title

### DIFF
--- a/src/adhocracy/lib/helpers/instance_helper.py
+++ b/src/adhocracy/lib/helpers/instance_helper.py
@@ -1,5 +1,6 @@
 from pylons.i18n import _
 
+from adhocracy import config
 from adhocracy.lib import logo
 from adhocracy.lib.helpers import url as _url
 
@@ -30,3 +31,22 @@ def settings_breadcrumbs(instance, member=None):
             member['label'],
             url(instance, member="settings/" + member['name']))
     return bc
+
+
+def area_title(identifier):
+    """identifier is typically the value of c.active_subheader_nav"""
+    if identifier == 'proposals':
+        return _("Proposals")
+    elif identifier == 'milestones':
+        return _("Milestones")
+    elif identifier == 'norms':
+        return _("Norms")
+    elif identifier == 'category':
+        return _("Categories")
+    elif identifier == 'members':
+        return _("Members")
+    else:
+        if config.get_bool('adhocracy.wording.intro_for_overview'):
+            return _(u"Intro")
+        else:
+            return _(u"Overview")

--- a/src/adhocracy/templates/instance/show.html
+++ b/src/adhocracy/templates/instance/show.html
@@ -4,7 +4,7 @@
 <%def name="title()">${_("Home")}</%def>
 
 <%def name="breadcrumbs()">
-    ${h.instance.breadcrumbs(c.page_instance)|n} ${h.url.link(_("Overview"), h.entity_url(c.page_instance))|n}
+    ${h.instance.breadcrumbs(c.page_instance)|n} ${h.url.link(h.instance.area_title('overview'), h.entity_url(c.page_instance))|n}
 </%def>
 
 

--- a/src/adhocracy/templates/navigation.html
+++ b/src/adhocracy/templates/navigation.html
@@ -194,36 +194,36 @@
                                   url=url)">
 
   ${nav_link(href=h.entity_url(c.instance),
-             text=_(u"Intro") if h.config.get_bool('adhocracy.wording.intro_for_overview') else _(u"Overview"),
+             text=h.instance.area_title('instance'),
              li_class=_class('instance'),
              id_='subnav-overview')}
 
   ${nav_link(href=h.base_url('/proposal'),
-             text=_("Proposals"),
+             text=h.instance.area_title('proposals'),
              li_class=_class('proposals'),
              condition=c.instance.show_proposals_navigation,
              id_='subnav-proposals')}
 
   ${nav_link(href=h.base_url('/milestone'),
-             text=_("Milestones"),
+             text=h.instance.area_title('milestones'),
              li_class=_class('milestones'),
              condition=c.instance.milestones,
              id_='subnav-milestones')}
 
   ${nav_link(href=h.base_url('/page'),
-             text=_("Norms"),
+             text=h.instance.area_title('norms'),
              li_class=_class('norms'),
              condition=c.instance.use_norms and c.instance.show_norms_navigation,
              id_='subnav-norms')}
 
   ${nav_link(href=h.base_url('/category'),
-             text=_("Categories"),
+             text=h.instance.area_title('category'),
              li_class=_class('category'),
              condition=c.instance.display_category_pages,
              id_='subnav-category')}
 
   ${nav_link(href=h.base_url('/user'),
-             text=_("Members"),
+             text=h.instance.area_title('members'),
              li_class=_class('members'),
              id_='subnav-members')}
 


### PR DESCRIPTION
This makes it easy to resolve an area identifier (e.g. 'proposals' or 'overview') to a human readble (and translated) title.
