### PR TITLE
fix proposal inline row spacing

### DIFF
--- a/src/adhocracy/static_src/stylesheets/components/_badge.scss
+++ b/src/adhocracy/static_src/stylesheets/components/_badge.scss
@@ -49,6 +49,7 @@
 
     img {
         margin-right: 0.5em;
+        vertical-align: bottom;
     }
     + div {
         overflow: hidden;

--- a/src/adhocracy/static_src/stylesheets/widgets/_proposal.scss
+++ b/src/adhocracy/static_src/stylesheets/widgets/_proposal.scss
@@ -11,12 +11,11 @@ ul.papers_list {
 }
 
 .proposals_pager {
-    .content_box {
-        @include clearfix;
+    .main_row {
+        @include pie-clearfix;
 
         > div {
             float: left;
-            margin-bottom: 0.5em;
         }
     }
     .showhide_button {
@@ -28,6 +27,7 @@ ul.papers_list {
         }
     }
     .proposal {
+        margin-top: 0.5em;
         padding: 1.5em;
         clear: both;
 

--- a/src/adhocracy/templates/proposal/tiles.html
+++ b/src/adhocracy/templates/proposal/tiles.html
@@ -58,12 +58,14 @@
 
 <%def name="row_inline(tile, proposal)">
     <li class="content_box ${'fresh' if tile.fresh else ''}">
-        ${_row(tile, proposal)}
-        <a class="button_small showhide_button"
-           data-target="#proposal-${proposal.id}"
-           data-target-speed="fast"
-           data-toggle-class="less"
-           href="#"></a>
+        <div class="main_row">
+            ${_row(tile, proposal)}
+            <a class="button_small showhide_button"
+               data-target="#proposal-${proposal.id}"
+               data-target-speed="fast"
+               data-toggle-class="less"
+               href="#"></a>
+        </div>
         <article class="proposal" style="display: none" id="proposal-${proposal.id}">
             <div class="body">
                 ${tiles.page.inline(proposal.description)}


### PR DESCRIPTION
This fixes two issues with the spacing of proposal inline rows (see #733):
-  The thumbnail image had `vertical-align: middle` resulting in spacing at the bottom
-  Instead of applying the margin between main row and preview to the preview it was applied to the main row. This way the spacing was always present, even if the preview was hidden.
