### PR TITLE
Add CorsMiddleware adding an Allow-Origin=* header

### DIFF
--- a/src/adhocracy/config/middleware.py
+++ b/src/adhocracy/config/middleware.py
@@ -11,6 +11,7 @@ from pylons.wsgiapp import PylonsApp
 from routes.middleware import RoutesMiddleware
 
 from adhocracy.lib.auth.authentication import setup_auth
+from adhocracy.lib.cors import CorsMiddleware
 from adhocracy.lib.instance import setup_discriminator
 from adhocracy.lib.machine_name import IncludeMachineName
 from adhocracy.lib.util import get_site_path
@@ -110,6 +111,7 @@ def make_app(global_conf, full_stack=True, static_files=True, **app_conf):
     if asbool(config.get('adhocracy.include_machine_name_in_header', 'false')):
         app = IncludeMachineName(app, config)
 
+    app = CorsMiddleware(app, config)
     app.config = config
 
     return app

--- a/src/adhocracy/lib/cors.py
+++ b/src/adhocracy/lib/cors.py
@@ -1,0 +1,31 @@
+class CorsMiddleware(object):
+    """ Set CORS header.
+
+    This middleware sets an Access-Control-Allow-Origin HTTP header allowing
+    scripts from other domains to load Adhocracy data.
+
+    In our case this is needed in the following case (non-relative URLs):
+
+    - User visits foo.adhocracy.lan
+    - Due to fanstatic loading everything from the main URL, a script is loaded
+      from adhocracy.lan/js/myscript.js
+    - This script wants to access JSON data from the same domain it comes from
+      (js.socialshareprivacy-1.5 does that)
+    - JSON from adhocracy.lan couldn't be loaded from foo.adhocracy.lan if
+      the respective header weren't set.
+
+    It would be sufficient to allow `*.adhocracy.lan` to access JSON data on
+    `adhocracy.lan`, but the CORS specs don't allow for that. Therefore we
+    allow everybody to use our data.
+
+    """
+
+    def __init__(self, app, config):
+        self.app = app
+        self.config = config
+
+    def __call__(self, environ, start_response):
+        def local_response(status, headers, exc_info=None):
+            headers.append(('Access-Control-Allow-Origin', '*'))
+            start_response(status, headers, exc_info)
+        return self.app(environ, local_response)


### PR DESCRIPTION
This is required due to the update of js.socialshareprivacy to 1.5 which
loads JSON translation files.

See docstring in CorsMiddleware for more details.
