### PR TITLE
remove all non ascii chars from CSS

### DIFF
--- a/src/adhocracy/static_src/stylesheets/components/_button.scss
+++ b/src/adhocracy/static_src/stylesheets/components/_button.scss
@@ -60,7 +60,7 @@ a.button_round {
 
     // icon
     &:before {
-        content: "✚";
+        content: "\271a";
         margin-right: 0.4em;
         color: #fff;
         background-color: $button-color;
@@ -79,12 +79,12 @@ a.button_round {
         @include background-image(linear-gradient(170deg, lighten($green, 14%), $green));
     }
     &.active:before {
-        content: "✔";
+        content: "\2714";
         background-color: $green;
         @include background-image(linear-gradient(170deg, lighten($green, 14%), $green));
     }
     &.active:hover:before, &.active:focus:before {
-        content: "×";
+        content: "\d7";
         background-color: $red;
         @include background-image(linear-gradient(170deg, lighten($red, 14%), $red));
     }

--- a/src/adhocracy/static_src/stylesheets/components/_modals.scss
+++ b/src/adhocracy/static_src/stylesheets/components/_modals.scss
@@ -153,6 +153,6 @@ html.overlay {
         width: 2em;
         line-height: 2;
         text-align: center;
-        content: "×";
+        content: "\d7";
     }
 }

--- a/src/adhocracy/static_src/stylesheets/components/_morelink.scss
+++ b/src/adhocracy/static_src/stylesheets/components/_morelink.scss
@@ -6,7 +6,7 @@
     white-space: nowrap;
 
     &:before {
-        content: "⟶";
+        content: "\27f6";
         text-decoration: none !important;
         font-weight: normal !important;
         position: absolute;


### PR DESCRIPTION
We had problems with non ascii characters in CSS in some installations. As unicode characters can be escaped there is no need to have any non-ascii characters in our CSS code. So this escape all of them.
