### PR TITLE
fixup 45444b9 fix register button spacing

### DIFF
--- a/src/adhocracy/static_src/stylesheets/components/_button.scss
+++ b/src/adhocracy/static_src/stylesheets/components/_button.scss
@@ -9,6 +9,7 @@
         color: #fff;
         line-height: 2;
         float: left;
+        margin-right: 1em;
         padding-right: 2em;
         min-width: 10em;
         position: relative;
@@ -23,6 +24,9 @@
             right: 0.75em;
             top: 50%;
             margin-top: -0.75em;
+        }
+        &:last-child {
+            margin-right: 0;
         }
     }
 }


### PR DESCRIPTION
45444b9 was meant to fix a tiny bug about `margin-right` on the instance join button (see image). However, the same CSS is used for multiple similar cases which were broken due to that "fix". The problem was that the spacing should be there if there is any more text after the button (e.g. "or _log in_").

While this is a tiny change I still created this pull request to avoid regressions like this one.

![join_spacing](https://f.cloud.github.com/assets/202576/2194747/776306d8-9891-11e3-9115-9a6231505294.png)
