### PR TITLE
add flex browser prefixes

### DIFF
--- a/src/adhocracy/static_src/stylesheets/components/_tile.scss
+++ b/src/adhocracy/static_src/stylesheets/components/_tile.scss
@@ -27,12 +27,12 @@ html.flexbox .tile-table {
     margin-left: -1em;
 
     .tile-row {
-        display: flex;
-        justify-content: space-between;
+        @include display(flex);
+        @include justify-content(space-between);
         margin: 4em 0;
     }
     .tile {
-        flex: 1;
+        @include flex(1);
         position: relative;
         margin: 0 1em;
 

--- a/src/adhocracy/static_src/stylesheets/general/_mixins.scss
+++ b/src/adhocracy/static_src/stylesheets/general/_mixins.scss
@@ -86,3 +86,24 @@
         text-decoration: none;
     }
 }
+
+// flex
+@mixin flex($args) {
+    flex: $args;
+    -webkit-flex: $args;
+    -ms-flex: $args;
+}
+@mixin display($arg) {
+    @if $arg == 'flex' {
+        display: flex;
+        display: -webkit-flex;
+        display: -ms-flex;
+    } @else {
+        display: $args;
+    }
+}
+@mixin justify-content($arg) {
+    justify-content: $arg;
+    -webkit-justify-content: $arg;
+    -ms-justify-content: $arg;
+}


### PR DESCRIPTION
Unfortunately there was a regression introduced in #757: Some browser support flex, but only with prefixes. In those browsers the tiles are currently displayed in a single full-width column.

This adds the missing browser prefixes. There are currently no compass mixins for that so I had to write my own.
