### PR TITLE
add optional profiling middleware on debug

### DIFF
--- a/buildouts/developtools.cfg
+++ b/buildouts/developtools.cfg
@@ -26,6 +26,7 @@ eggs +=
     adhocracy [test]
     Babel
     ipdb
+    Werkzeug
     WebError
 
 [paster]

--- a/src/adhocracy/config/middleware.py
+++ b/src/adhocracy/config/middleware.py
@@ -54,6 +54,11 @@ def make_app(global_conf, full_stack=True, static_files=True, **app_conf):
     # The Pylons WSGI app
     app = PylonsApp(config=config)
 
+    if debug and asbool(app_conf.get('adhocracy.enable_profiling', False)):
+        from werkzeug.contrib.profiler import ProfilerMiddleware
+        app = ProfilerMiddleware(app, sort_by=('ncalls',),
+                                 restrictions=('src/adhocracy/.*', 25))
+
     # Routing/Session/Cache Middleware
     app = RoutesMiddleware(app, config['routes.map'])
     if config.get('adhocracy.session.implementation', 'beaker') == 'cookie':


### PR DESCRIPTION
This adds an optional profiling middleware which can be activated by adding `adhocracy.enable_profiling = True` in `etc/adhocracy.ini`.

I chose [werkzeug](http://werkzeug.pocoo.org/docs/contrib/profiler/) over [paster](http://pythonpaste.org/modules/debug.profile.html) because it offered more customization options and a more useful output. Note that this reverts #255.
