### PR TITLE
fix query_param encoding

### DIFF
--- a/src/adhocracy/lib/helpers/site_helper.py
+++ b/src/adhocracy/lib/helpers/site_helper.py
@@ -95,6 +95,8 @@ def base_url(path='', instance=CURRENT_INSTANCE, absolute=False,
 
     if query_params:
         result += '&' if '?' in result else '?'
+        u = lambda s: unicode(s).encode('utf-8')
+        query_params = [(u(k), u(v)) for (k, v) in query_params.iteritems()]
         result += urllib.urlencode(query_params)
     elif query_string:
         result += '&' if '?' in result else '?'

--- a/src/adhocracy/lib/helpers/url.py
+++ b/src/adhocracy/lib/helpers/url.py
@@ -46,6 +46,8 @@ def build(instance, base, id, query=None, anchor=None, member=None,
     url = append_member_and_format(url, member, format)
     if query is not None:
         url += '&' if '?' in url else '?'
+        u = lambda s: unicode(s).encode('utf-8')
+        query = [(u(k), u(v)) for (k, v) in query.iteritems()]
         url += urllib.urlencode(query)
     if anchor is not None:
         url += "#" + anchor


### PR DESCRIPTION
This fixes a bug where an exception is thrown for any non-ascii chars in query_param for both `h.url.build` and `h.base_url`.

That bug is a regression from e9c6a2c. See also #782 because it also deals with unicode issues in urllib.
