### PR TITLE
fix links with children in overlay

### DIFF
--- a/src/adhocracy/static/javascripts/adhocracy.js
+++ b/src/adhocracy/static/javascripts/adhocracy.js
@@ -1334,15 +1334,15 @@ $(document).ready(function () {
         // registering this event on parent element to also catch
         // events from generated elements
         $('html').on('click', 'a[href]', function(e) {
-            if (e.target.href[0] != '#' && !e.target.target) {
-                e.target.target = '_top';
+            if (this.href[0] != '#' && !this.target) {
+                this.target = '_top';
             }
-            if (e.target.target === '_self') {
-                e.target.href = overlay_url(e.target.href);
+            if (this.target === '_self') {
+                this.href = overlay_url(this.href);
             }
         });
         $('html').on('submit', 'form', function(e) {
-            e.target.action = overlay_url(e.target.action);
+            this.action = overlay_url(this.action);
         });
     }
 });


### PR DESCRIPTION
This replaces `e.target` by `this` in the code from #802. According to http://api.jquery.com/on/ `e.target` is the innermost element the event originates from. `this` is not (as I had previously though) the element `on()` is called on but the one in the second argument to `on()`. So this fixes cases were links have child elements (e.g. images).
