### PR TITLE
add missing options on static instance overview

### DIFF
--- a/src/adhocracy/controllers/instance.py
+++ b/src/adhocracy/controllers/instance.py
@@ -261,7 +261,9 @@ class InstanceController(BaseController):
             data = {
                 'static': page,
                 'body_html': render_body(page.body),
+                'full_width': True,
             }
+            c.body_css_classes += page.css_classes
             return render("/static/show.html", data,
                           overlay=format == 'overlay')
 


### PR DESCRIPTION
This adds two missing options to the changes from #814:
-  add CSS classes
-  use the `full_width` feature from #818 (note: that is only available in the staticpages branch)
