### PR TITLE
full width instance background

### DIFF
--- a/src/adhocracy/static_src/stylesheets/widgets/_subheader.scss
+++ b/src/adhocracy/static_src/stylesheets/widgets/_subheader.scss
@@ -3,6 +3,7 @@
     @include background-image(linear-gradient(to bottom, white, $bg2));
     @include box-shadow(0 -1em 0.5em -1em rgba(0,0,0,0.1) inset);
     display: block;
+    position: relative;
     overflow: hidden;
     margin-bottom: 3em;
     overflow: hidden;
@@ -12,10 +13,10 @@
     }
     .background-image {
         position: absolute;
-        width: 120%;
+        width: 100%;
         height: 100%;
         top: 0;
-        left: -10%;
+        left: 0;
         background-size: cover;
         background-position: 50%;
         opacity: 0.2;

--- a/src/adhocracy/templates/navigation.html
+++ b/src/adhocracy/templates/navigation.html
@@ -123,10 +123,10 @@
                                  search_button_text=None, url=None, background=None)">
 
   <div id="subheader" class="${'logo' if logo else ''}">
+      %if background is not None:
+      <div style="background-image: url('${background}')" class="background-image"></div>
+      %endif
       <div class="page_wrapper">
-        %if background is not None:
-        <div style="background-image: url('${background}')" class="background-image"></div>
-        %endif
         <div id="logo_row">
             <div id="organisation_logo">
                 %if url:


### PR DESCRIPTION
This changes the instance subheader background introduced in #793 to stretch across the whole available space instead of filling 120% of `.page_wrapper`.

Maybe we should ask someone from the office before merging if this is really what they want.
A possible issue is that we have absolutely no control over the ratio of the image.  But with the upcoming responsive design we don't have that control anyway.
