### PR TITLE
Move mass message button to members sidebar

### DIFF
--- a/src/adhocracy/templates/instance/show.html
+++ b/src/adhocracy/templates/instance/show.html
@@ -80,7 +80,6 @@ ${c.events_pager.here()}
 </%block>
 
 <%block name="sidebar">
-${components.message_button(c.instance)}
 %if h.has_permission("watch.instance"):
 ${components.watch(c.instance)}
 %endif

--- a/src/adhocracy/templates/user/index.html
+++ b/src/adhocracy/templates/user/index.html
@@ -26,6 +26,7 @@
 </%block>
 
 <%block name="sidebar">
+    ${components.message_button(c.instance)}
     %if c.instance is not None and (h.has_permission('global.admin') or can.instance.authenticated_edit(c.instance)):
     <a class="button_round" href="${h.entity_url(c.instance, member='members_import')}">Import Members</a>
     %endif


### PR DESCRIPTION
An in-place mass message button has been added to the instance overview
sidebar in aeee34d10999701fa48110a7eb05612a5e2273c3.

This commit moves this button to the members list sidebar, where it is
expected to be in context.
