### PR TITLE
fixup "make all badge select forms look alike"

### DIFF
--- a/src/adhocracy/templates/instance/badges.html
+++ b/src/adhocracy/templates/instance/badges.html
@@ -18,12 +18,12 @@
 
     %if c.badges:
     <ul class="nobullet">
-        %for badge in c.badges:
+        %for b in c.badges:
         <li>
             <label>
-                <input type="checkbox" value="${badge.id}"
+                <input type="checkbox" value="${b.id}"
                        name="badge" />
-                ${badge_tiles.badge(badge, force_visible=True)}
+                ${badge_tiles.badge(b, force_visible=True)}
                 %if not b.visible:
                 <em>(${_('invisible')})</em>
                 %endif


### PR DESCRIPTION
Thsi is a fixup for a2c5ceb4. I mixed `badge` and `b` there which of course caused a 500 error.
