### PR TITLE
Redirect velruse logins back to the page where login was performed

### DIFF
--- a/src/adhocracy/templates/openid/form.html
+++ b/src/adhocracy/templates/openid/form.html
@@ -13,7 +13,7 @@ else:
  <div>${_("Single sign-on services allow you to use a single login on many web sites.")}</div>
  <div class="openid_btns">
    %if 'facebook' in login_types:
-   <a href="javascript:{}" onclick="document.getElementById('facebook_login_form').submit();">
+   <a href="${h.get_redirect_url('velruse/login_with_velruse')}" class="${components.add_patch_camefrom_class()}">
      <img class="openid_large_btn" src="/velruse/facebook_login.png" alt="${_('Login with Facebook')}" />
    </a>
    %endif
@@ -25,9 +25,3 @@ else:
     <input class="openid_submit" type="submit" value="${signin_text}" />
   </div>
 </form>
-
-%if 'facebook' in login_types:
-<form id="facebook_login_form" action="${h.velruse_url('/login/facebook')}"
-      method="post" style="display: none">
-</form>
-%endif

--- a/src/adhocracy/templates/velruse/redirect_post.html
+++ b/src/adhocracy/templates/velruse/redirect_post.html
@@ -1,0 +1,18 @@
+<%inherit file="/template.html" />
+<%def name="title()">${_("Logging in") |n}</%def>
+
+<%block name="main">
+    <div>
+        ${_("You are being logged in.")}
+    </div>
+</%block>
+
+<form id="facebook_login_form" action="${h.velruse_url('/login/facebook')}"
+      method="post" style="display: none">
+</form>
+
+<script type="text/javascript">
+    $(document).ready( function() {
+        $("#facebook_login_form").submit()
+    })
+</script>


### PR DESCRIPTION
After logging in with Facebook(velruse), the user is redirected to URL defined by the came_from GET parameter.
Velruse can not redirect to custom URIs when used as a service and can then only be used with POST,
so adhocracy first remembers the users current URI, redirects her to a page where a login form is automatically send and then the redirect wanted is performed.
