### PR TITLE
Add new permission 'user.badge'

### DIFF
--- a/src/adhocracy/controllers/user.py
+++ b/src/adhocracy/controllers/user.py
@@ -1361,7 +1361,7 @@ class UserController(BaseController):
     def edit_badges(self, id, errors=None, format=u'html'):
         c.badges, c.instance_badges = self._allowed_badges()
         c.page_user = get_entity_or_abort(model.User, id)
-        require.user.supervise(c.page_user)
+        require.user.badge(c.page_user)
         defaults = {'badge': [str(badge.id) for badge in c.page_user.badges]}
         return formencode.htmlfill.render(
             render("/user/badges.html", overlay=format == u'overlay'),
@@ -1372,7 +1372,7 @@ class UserController(BaseController):
     @validate(schema=UserBadgesForm(), form='edit_badges')
     def update_badges(self, id):
         user = get_entity_or_abort(model.User, id)
-        require.user.supervise(user)
+        require.user.badge(user)
         want = set(self.form_result.get('badge'))
 
         allowed = self._all_allowed_badges()

--- a/src/adhocracy/lib/auth/user.py
+++ b/src/adhocracy/lib/auth/user.py
@@ -49,6 +49,11 @@ def message(check, u):
         check.other('no_member_in_instance', not u.is_member(c.instance))
 
 
+def badge(check, u):
+    check.readonly()
+    check.perm('user.badge')
+
+
 def supervise(check, u):
     check.readonly()
     check.other('not_in_instance', not c.instance)

--- a/src/adhocracy/lib/install.py
+++ b/src/adhocracy/lib/install.py
@@ -141,6 +141,7 @@ def setup_entities(config, initial_setup):
         u'user.message': [advisor],
         u'user.show': [anonymous],
         u'user.view': [anonymous],
+        u'user.badge': [moderator],
         u'vote.cast': [voter],
         u'vote.prohibit': [organization],
         u'watch.create': [observer, default],

--- a/src/adhocracy/templates/user/show.html
+++ b/src/adhocracy/templates/user/show.html
@@ -170,11 +170,11 @@
         </form>
         %endif
 
-        %if c.visible_badges or not c.dashboard and can.user.supervise(c.page_user):
+        %if c.visible_badges or not c.dashboard and can.user.badge(c.page_user):
         <h6>
             ${_('User badges')}
 
-            %if not c.dashboard and can.user.supervise(c.page_user):
+            %if not c.dashboard and can.user.badge(c.page_user):
             <div class="utility">
                 <a href="${h.entity_url(c.page_user, member='badges')}" class="button_small" rel="#overlay-form">
                     ${_("edit")}


### PR DESCRIPTION
This adds the permission `user.badge` and assigns it to moderators by default. This was before tied to the permission to change user groups.

You may consider this part of #367.
