### PR TITLE
gitignore generated css

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,7 +53,7 @@ buildout-*.cfg
 /python
 /.cache
 .sass-cache
-src/adhocracy/static/stylesheets/adhocracy.css
+src/adhocracy/static/stylesheets/adhocracy*.css
 src/adhocracy/tests/loadtests/data
 src/adhocracy/static/stylesheets/min/
 src/js.socialshareprivacy/


### PR DESCRIPTION
Apart from the main adhocarcy.css additional stylesheets may be gerenated (e.g. Themes from #791). This adds those to .gitignore.

I created this pull request because I was not completely sure about the wildcard and because it is not urgent.
