### PR TITLE
delete proposal description only if exists

### DIFF
--- a/src/adhocracy/model/proposal.py
+++ b/src/adhocracy/model/proposal.py
@@ -213,7 +213,8 @@ class Proposal(Delegateable):
         Delegateable.delete(self, delete_time=delete_time,
                             delete_children=False)
 
-        self.description.delete(delete_time=delete_time)
+        if self.description:
+            self.description.delete(delete_time=delete_time)
 
         for selection in self.selections:
             selection.delete(delete_time=delete_time)


### PR DESCRIPTION
This is a fixup to #842. It turns out that `proposal.description` is nullable.
