### PR TITLE
Fix Page.unusedTitle

### DIFF
--- a/src/adhocracy/model/page.py
+++ b/src/adhocracy/model/page.py
@@ -120,8 +120,10 @@ class Page(Delegateable):
     @classmethod
     def unusedTitle(cls, title, instance_filter=True, functions=None,
                     include_deleted=False, selection=None):
+        from adhocracy.lib.text import title2alias
+        label = title2alias(title)
         q = meta.Session.query(Page)\
-            .filter(Page.label == title)
+            .filter(Page.label == label)
         if not include_deleted:
             q = q.filter(or_(Page.delete_time == None,  # noqa
                              Page.delete_time > datetime.utcnow()))


### PR DESCRIPTION
unusedTitle compared the title with the label without conversion which resulted in many false positives.

To reproduce the issue, try to create multiple pages and proposals with the title "foo bar" (including the space).
