### PR TITLE
Fix category url for global categories

### DIFF
--- a/src/adhocracy/templates/components.html
+++ b/src/adhocracy/templates/components.html
@@ -494,7 +494,7 @@ ${caller.body()}
 
 
 <%def name="category_link(category)">
-    %if c.instance is not None and c.instance.display_category_pages:
+    %if category.instance is not None and category.instance.display_category_pages:
     <a href="${h.entity_url(category)}">${category}</a>
     %else:
     ${category}


### PR DESCRIPTION
This is a fixup to #847 for cases where categories are global. Note that category pages are currently only available for non-global categories.
