### PR TITLE
fix page/proposal title validation

### DIFF
--- a/src/adhocracy/controllers/page.py
+++ b/src/adhocracy/controllers/page.py
@@ -42,7 +42,7 @@ NoPage = NoneObject()
 
 class PageCreateForm(formencode.Schema):
     allow_extra_fields = True
-    title = forms.UnusedTitle()
+    title = forms.ValidTitle(unused_label=True)
     text = validators.String(max=20000, min=0, not_empty=False,
                              if_empty=None, if_missing=None)
     parent = forms.ValidPage(if_missing=None, if_empty=None, not_empty=False)
@@ -77,7 +77,7 @@ class PageEditForm(formencode.Schema):
 
 class PageUpdateForm(formencode.Schema):
     allow_extra_fields = True
-    title = forms.UnusedTitle()
+    title = forms.ValidTitle()
     variant = forms.VariantName(not_empty=True)
     text = validators.String(max=20000, min=0, not_empty=False,
                              if_empty=None, if_missing=None)

--- a/src/adhocracy/controllers/proposal.py
+++ b/src/adhocracy/controllers/proposal.py
@@ -23,6 +23,8 @@ from adhocracy.lib.templating import OVERLAY_SMALL
 from adhocracy.lib.queue import update_entity
 from adhocracy.lib.util import get_entity_or_abort
 from adhocracy.lib.util import split_filter
+from adhocracy.lib.text import title2alias
+from adhocracy.lib.text import variant_normalize
 
 import adhocracy.lib.text as text
 
@@ -41,7 +43,7 @@ class PageInclusionForm(formencode.Schema):
 
 class ProposalCreateForm(ProposalNewForm):
     pre_validators = [formencode.variabledecode.NestedVariables()]
-    label = validators.String(min=3, max=254, not_empty=True)
+    title = forms.ValidProposalTitle(unused_label=True)
     text = validators.String(max=20000, min=4, not_empty=True)
     tags = validators.String(max=20000, not_empty=False, if_missing=None)
     amendment = validators.StringBool(not_empty=False, if_empty=False,
@@ -54,9 +56,6 @@ class ProposalCreateForm(ProposalNewForm):
                                   if_missing=False)
     wiki = validators.StringBool(not_empty=False, if_empty=False,
                                  if_missing=False)
-    chained_validators = [
-        forms.UnusedProposalTitle(),
-    ]
 
 
 class ProposalEditForm(formencode.Schema):
@@ -64,7 +63,7 @@ class ProposalEditForm(formencode.Schema):
 
 
 class ProposalUpdateForm(ProposalEditForm):
-    label = validators.String(min=3, max=254, not_empty=True)
+    title = forms.ValidProposalTitle()
     text = validators.String(max=20000, min=4, not_empty=True)
     wiki = validators.StringBool(not_empty=False, if_empty=False,
                                  if_missing=False)
@@ -77,9 +76,6 @@ class ProposalUpdateForm(ProposalEditForm):
                                   if_missing=False)
     badge = formencode.foreach.ForEach(forms.ValidDelegateableBadge())
     thumbnailbadge = formencode.foreach.ForEach(forms.ValidThumbnailBadge())
-    chained_validators = [
-        forms.UnusedProposalTitle(),
-    ]
 
 
 class ProposalFilterForm(formencode.Schema):
@@ -240,6 +236,10 @@ class ProposalController(BaseController):
             return self.new(errors=i.unpack_errors(), page=page,
                             amendment=amendment)
 
+        title = self.form_result.get('title')
+        label = title2alias(title)
+        variant = variant_normalize(title)
+
         pages = self.form_result.get('page', [])
         is_amendment = self.form_result.get('amendment', False)
 
@@ -257,14 +257,14 @@ class ProposalController(BaseController):
                 'error')
             return self.new()
         proposal = model.Proposal.create(c.instance,
-                                         self.form_result.get("label"),
+                                         label,
                                          c.user, with_vote=can.user.vote(),
                                          tags=self.form_result.get("tags"),
                                          is_amendment=is_amendment)
         proposal.milestone = self.form_result.get('milestone')
         model.meta.Session.flush()
         description = model.Page.create(c.instance,
-                                        self.form_result.get("label"),
+                                        title,
                                         self.form_result.get('text'),
                                         c.user,
                                         function=model.Page.DESCRIPTION,
@@ -283,8 +283,6 @@ class ProposalController(BaseController):
             page = page.get('id')
             if page is None or page.function != model.Page.NORM:
                 continue
-            var_val = forms.VariantName()
-            variant = var_val.to_python(self.form_result.get('label'))
             if not can.norm.edit(page, variant) or \
                not can.selection.create(proposal):
                 continue
@@ -364,7 +362,6 @@ class ProposalController(BaseController):
 
         require.proposal.edit(c.proposal)
 
-        c.proposal.label = self.form_result.get('label')
         c.proposal.milestone = self.form_result.get('milestone')
         model.meta.Session.add(c.proposal)
 
@@ -389,7 +386,7 @@ class ProposalController(BaseController):
 
         _text = model.Text.create(c.proposal.description, model.Text.HEAD,
                                   c.user,
-                                  self.form_result.get('label'),
+                                  self.form_result.get('title'),
                                   self.form_result.get('text'),
                                   parent=c.proposal.description.head,
                                   wiki=wiki)

--- a/src/adhocracy/forms/__init__.py
+++ b/src/adhocracy/forms/__init__.py
@@ -9,8 +9,8 @@ from common import ValidUserBadge, ValidUserBadges, \
     ValidThumbnailBadge
 from common import ValidWatch, ValidRef, ValidTagging, ValidTag
 from common import ValidPage, ValidText, ValidPageFunction
-from common import ExistingUserName, VariantName, UnusedTitle,\
-    UnusedProposalTitle
+from common import ExistingUserName, VariantName, ValidTitle,\
+    ValidProposalTitle
 from common import FORBIDDEN_NAMES
 from common import ValidLocale
 from common import ValidDate

--- a/src/adhocracy/model/page.py
+++ b/src/adhocracy/model/page.py
@@ -118,10 +118,8 @@ class Page(Delegateable):
         return pages
 
     @classmethod
-    def unusedTitle(cls, title, instance_filter=True, functions=None,
-                    include_deleted=False, selection=None):
-        from adhocracy.lib.text import title2alias
-        label = title2alias(title)
+    def unused_label(cls, label, instance_filter=True, functions=None,
+                    include_deleted=False):
         q = meta.Session.query(Page)\
             .filter(Page.label == label)
         if not include_deleted:
@@ -130,20 +128,7 @@ class Page(Delegateable):
         if ifilter.has_instance() and instance_filter:
             q = q.filter(Page.instance == ifilter.get_instance())
 
-        matches = q.all()
-
-        if selection is not None:
-            def same_selection(page):
-                try:
-                    return (page.function == Page.DESCRIPTION and
-                            page.proposal.is_amendment and
-                            page.proposal.selection.page == selection)
-                except Exception as e:
-                    log.warn(e)
-                    return False
-            matches = filter(same_selection, matches)
-
-        return not bool(matches)
+        return not q.count()
 
     @classmethod
     def count(cls, **kwargs):

--- a/src/adhocracy/templates/proposal/edit.html
+++ b/src/adhocracy/templates/proposal/edit.html
@@ -21,7 +21,7 @@
         <fieldset>
             <legend>${_("Amendment title") if c.proposal.is_amendment else _("Proposal title")}</legend>
             <div class="input_wrapper">
-                <input type="text" class="title" name="label" autofocus value="${c.proposal.title}"
+                <input type="text" class="title" name="title" autofocus value="${c.proposal.title}"
                        placeholder="${_("New amendment") if c.proposal.is_amendment else _("New proposal")}" />
             </div>
         </fieldset>

--- a/src/adhocracy/templates/proposal/new.html
+++ b/src/adhocracy/templates/proposal/new.html
@@ -24,7 +24,7 @@
         <fieldset>
             <legend>${_("Amendment title") if c.amendment else _("Proposal title")}</legend>
             <div class="input_wrapper">
-                <input type="text" class="title" name="label" autofocus
+                <input type="text" class="title" name="title" autofocus
                        placeholder="${_("New amendment") if c.amendment else _("New proposal")}" />
             </div>
         </fieldset>


### PR DESCRIPTION
Unfortunately, #849 did not really solve the issue but revealed many more problems. As a result I refactored the whole page/proposal form validation.

I am sorry for the large commit. I did not know how to split this up. Some notes that might be helpful:
-  I made a clear distinction between `title` (of a text), `label` (of a page) and `variant` (not sure what this is)
-  I basically reverted e829af4 because on second thought, page labels should be unique on the instance level (because they are used in URLs) and the description of a proposal _is_ a page.
-  While I was sure that labels should be unique, I was not so sure about `title`. I chose to not make this unique. This means that user can not create a page/proposal with an existing `title` (because that would result in a duplicate `label`) but they can later change the `title` (which leaves the `label` as is).
