### PR TITLE
fix cancel/came_from link in badge edit form

### DIFF
--- a/src/adhocracy/controllers/badge.py
+++ b/src/adhocracy/controllers/badge.py
@@ -454,6 +454,9 @@ class BadgeController(BaseController):
             defaults['select_child_description'] =\
                 badge.select_child_description
 
+        if not c.came_from:
+            c.came_from = self.base_url
+
         return htmlfill.render(render(self.form_template, data,
                                       overlay=format == u'overlay',
                                       overlay_size=OVERLAY_SMALL),


### PR DESCRIPTION
This is a fixup to #831. The `came_from` fallback for badge edit forms was missing.
