### PR TITLE
Make sure badge impact is commited before proposal update

### DIFF
--- a/src/adhocracy/controllers/badge.py
+++ b/src/adhocracy/controllers/badge.py
@@ -658,7 +658,6 @@ class BadgeController(BaseController):
         badge.visible = visible
         badge.description = description
         badge.instance = instance
-        meta.Session.commit()
         if badge.impact != impact:
             badge.impact = impact
             meta.Session.commit()


### PR DESCRIPTION
On badge impact update, all badged entities need to be reindexed. This
makes sure the reindexing takes place after setting the impact.
