### PR TITLE
Only create queue object once

### DIFF
--- a/src/adhocracy/lib/queue.py
+++ b/src/adhocracy/lib/queue.py
@@ -108,6 +108,7 @@ class RQConfig(object):
     in_worker = False
 
     def __init__(self, async, host, port, queue_name):
+        self._queue = None
         if host and port and queue_name:
             self.host = host
             self.port = int(port)
@@ -132,9 +133,12 @@ class RQConfig(object):
 
     @property
     def queue(self):
+        if self._queue is not None:
+            return self._queue
         if not self.use_redis or (not self.in_worker and self.force_sync):
             return None
-        return Queue(self.queue_name, connection=self.connection)
+        self._queue = Queue(self.queue_name, connection=self.connection)
+        return self._queue
 
     @classmethod
     def setup_from_config(cls, config):


### PR DESCRIPTION
This makes sure the `rq.Queue` object is only created once.

I haven't checked on performance gains, but it feels wrong reconstructing the queue over and over again. In my understanding caching the queue should be save.
