### PR TITLE
scroll into view if needed after overlay resize

### DIFF
--- a/src/adhocracy/static/javascripts/adhocracy.js
+++ b/src/adhocracy/static/javascripts/adhocracy.js
@@ -307,7 +307,7 @@ var adhocracy = adhocracy || {};
             });
 
             resize(300);
-            autoResize('fast', 200);
+            autoResize(200, 500);
 
             if (trigger.attr('rel') === '#overlay-form') {
                 $('.savebox .cancel', iframe.contents()).click(function(e) {


### PR DESCRIPTION
If you are in a long overlay and trigger a resize the overlay might resize out of view. To prevent this we want to scroll along with the resizing if needed.

Note that there is no scrolling if the overlay does not leave the visible area. If it does, we always scroll to the top of the overlay.

At first I had tried to create a more generic function: An animated version of [scrollIntoView](https://developer.mozilla.org/en-US/docs/Web/API/Element.scrollIntoView). This did not succeed because at the time this function would have been called there was no way of deducing the target height from the element itself. So I went this specific solution.
