### PR TITLE
fix traverse_watchlist merge argument order

### DIFF
--- a/src/adhocracy/lib/watchlist.py
+++ b/src/adhocracy/lib/watchlist.py
@@ -52,7 +52,7 @@ def traverse_watchlist(entity):
 
     def merge(inner, outer):
         return inner + [w for w in outer if
-                        w.user not in [w.user for w in inner]]
+                        w.user not in [ww.user for ww in inner]]
 
     watches = Watch.all_by_entity(entity)
 


### PR DESCRIPTION
traverse_watchlist is used for example to check which users
should receive a notification. Unfortunately there was a bug that
resulted in completely wrong return values.
