### PR TITLE
warn user about exposing email address when creating message

### DIFF
--- a/src/adhocracy/templates/massmessage/new.html
+++ b/src/adhocracy/templates/massmessage/new.html
@@ -69,6 +69,8 @@
             ${_('Customize sender name: ')} <input type="text" name="sender_name" value="${c.user.name}" />
           </label>
         %endif
+
+        <p class="help-block">${_("Please note that your e-mail address may be included in this message to give the recipient a method to reply to you.")}</p>
       </fieldset>
 
       <div class="mainbar">

--- a/src/adhocracy/templates/message/new.html
+++ b/src/adhocracy/templates/message/new.html
@@ -19,6 +19,8 @@
 
       <div style="clear:both;"></div>
 
+      <p class="help-block">${_("Please note that your e-mail address may be included in this message to give the recipient a method to reply to you.")}</p>
+
       <div class="mainbar">
           ${components.savebox(h.base_url("/user/%s" % c.page_user.user_name), save_text=_("Send"))}
       </div>


### PR DESCRIPTION
This warning was lost in 54b8d359d.

There was some discussion about whether exposing the email address is necessary in the first place. The alternative would be to link to the users "send message" form (`/user/{username}/message/new`). This would be a consequent thing to do as we have removed a lot of email specific functionality since #615.  (see also #869, especially 2af6121)
