### PR TITLE
Avoid uneccessary delegateable invalidation

### DIFF
--- a/src/adhocracy/lib/cache/invalidate.py
+++ b/src/adhocracy/lib/cache/invalidate.py
@@ -33,12 +33,13 @@ def invalidate_page(page):
     invalidate_delegateable(page)
 
 
-def invalidate_delegateable(d):
+def invalidate_delegateable(d, include_parents=True):
     clear_tag(d)
-    for p in d.parents:
-        invalidate_delegateable(p)
-    if not len(d.parents):
-        clear_tag(d.instance)
+    if include_parents:
+        for p in d.parents:
+            invalidate_delegateable(p)
+        if not len(d.parents):
+            clear_tag(d.instance)
 
 
 def invalidate_revision(rev):
@@ -87,7 +88,7 @@ def invalidate_instance(instance):
     # muharhar cache epic fail
     clear_tag(instance)
     for d in instance.delegateables:
-        invalidate_delegateable(d)
+        invalidate_delegateable(d, include_parents=False)
 
 
 def invalidate_tagging(tagging):


### PR DESCRIPTION
When invalidating instances, each delegeteable in that instance is
invalidated. So there is no need to invalidate the parent delegateables
or the instance again.

I guess more optimization could be done here. This speed up proposal
creation by about 15x on my test installation.
