### PR TITLE
Proper treatment of non-existent subdomains (fixes #626)

### DIFF
--- a/src/adhocracy/lib/instance/discriminator.py
+++ b/src/adhocracy/lib/instance/discriminator.py
@@ -1,6 +1,7 @@
 import logging
 
 from adhocracy import model
+from adhocracy.lib.helpers.site_helper import base_url
 from paste.deploy.converters import asbool
 from webob import Response
 
@@ -58,8 +59,9 @@ class InstanceDiscriminatorMiddleware(object):
                     # Fair handling of users prefixing everything with www.
                     if instance_key == 'www':
                         response.status_int = 301
-                        response.headers['location'] = environ.get('PATH_INFO',
-                                                                   '')
+                        response.headers['location'] = \
+                            base_url(environ.get('PATH_INFO', '/'),
+                                     absolute=True, config=self.config)
                         return response(environ, start_response)
                 response.status_int = 404
                 return response(environ, start_response)


### PR DESCRIPTION
This commit does two useful things at once, I'm too lazy to artificially
split them up:
1. Show proper 404 instead of white page for non-existing URLs (this is
   #626). This was due to the StatusCodeRedirect middleware running into
   
   the same exceptional case in the InstanceDiscriminatorMiddleware again
   when trying to resolve http://nonexistent.adhocracy.lan/error/document
   and is fixed by setting the HTTP_HOST environment variable to the base
   adhocracy domain.
2. Prefixing a non-relative_url installation with www we're now being
   redirected to the real URL, i.e. the corresponding path in the main
   domain instead of silently defaulting to that resource.
