### PR TITLE
Fix diazo rules path

### DIFF
--- a/etc/adhocracy.ini.in
+++ b/etc/adhocracy.ini.in
@@ -71,7 +71,7 @@ pipeline = theme
 [filter:theme]
 use = egg:diazo
 read_network = True
-rules = ${parts.adhocracy_code.absolute_theme_dir}/rules.xml
+rules = file:/${parts.adhocracy_code.absolute_theme_dir}/rules.xml
 prefix = /static_theme
 doctype = <!DOCTYPE html>
 {% if parts.adhocracy.debug == 'True' %}debug = true  {% end %}


### PR DESCRIPTION
If the diazo rules path isn't forced to use the file protocol, diazo
first tries to resolve the rules files (rules.xml, rules_notheme.xml,
rules_header.xml etc.) from the Adhocracy server. As these paths do not
exist, Adhocracy returns the /error/document page with status code 404
and Diazo then tries to find the file in the filesystem. In most themes
this results in 4*2=8 unsuccessful calls to Adhocracy on system startup.

Therefore system startup performance is increased significantly on
systems using diazo theming.

Note that this would finally fix the "No such instance: localhost,
defaulting" warnings which were only silenced in
94c74831e3992af212ac2c59f7ad9ec947cd82ae.
