### PR TITLE
Decrease obstructiveness of SSO warning

### DIFF
--- a/src/adhocracy/static_src/stylesheets/widgets/_openid.scss
+++ b/src/adhocracy/static_src/stylesheets/widgets/_openid.scss
@@ -43,16 +43,7 @@
     background-color: $bg1;
 }
 
-.sso_form_inhibitor {
-    position: absolute;
-    width: 100%;
-    height: 100%;
-    background: $bg1;
-    background: rgba($bg1, 0.8);
-    text-align: center;
-
-    p {
-        max-width: 34em;
-        margin: 1em auto;
-    }
+.sso_warning {
+    padding: 0 2em;
+    margin-bottom: 0;
 }

--- a/src/adhocracy/templates/sso.html
+++ b/src/adhocracy/templates/sso.html
@@ -3,10 +3,8 @@
 
 %if 'openid' in login_types or 'facebook' in login_types:
 <div class="sso_form">
-    <div class="sso_form_inhibitor">
-        <p>${_(u'Alternatively you can log in using various external accounts. Please be aware that the login via external providers may cause security and privacy related risks.')}</p>
-        <a class="button" href="#" onclick="$('.sso_form_inhibitor').hide(); return false;">${_('I understand the risk')}</a>
-    </div>
+
+    <p class="sso_warning">${_(u'Alternatively you can log in using various external accounts. Please be aware that the login via external providers may cause security and privacy related risks.')}</p>
 
     %if 'openid' in login_types:
     <% c.openid_scenario = scenario %>


### PR DESCRIPTION
We received feedback that the Facebook login wasn't visible enough
anymore. Therefore the warning overlay is changed to a simple message on
top of the form.

This might be changed to a proper warning later as many users don't
notice simple messages.
