### PR TITLE
Fix openid username form

### DIFF
--- a/src/adhocracy/templates/openid/username.html
+++ b/src/adhocracy/templates/openid/username.html
@@ -9,10 +9,13 @@
 <h1>${_("Select a user name")}</h1>
 
     <div class="infobox">
-        ${_('A unique user name is required for you complete sign up and '
-            'login. The user name "%s" received from your OpenID provider is '
+        ${_('A unique user name is required for you to complete sign up and '
+            'login.')}
+        %if c.openid_username is not None:
+        ${_('The user name "%s" received from your OpenID provider is '
             'invalid or already used. Please provide a different, unique user '
             'name.') % c.openid_username}
+        %endif
     </div>
 
 <div class="mainbar">


### PR DESCRIPTION
Don't show meaningless message if no username is retrieved by OpenID.
