### PR TITLE
Feature fix language negotiation

### DIFF
--- a/src/adhocracy/i18n/__init__.py
+++ b/src/adhocracy/i18n/__init__.py
@@ -6,6 +6,7 @@ import string
 import pytz
 import babel
 from babel import Locale
+from babel.core import LOCALE_ALIASES
 import babel.dates
 import formencode
 from pylons.i18n import _
@@ -31,14 +32,15 @@ LOCALES = [babel.Locale('de', 'DE'),
 
 LOCALE_STRINGS = map(str, LOCALES)
 
-LOCALE_ALIASES = {
-    'pt': 'pt_BR',
-}
 # Babel language negotiation can only compare language codes using the same
 # separator. As we use underscores and browsers send dashes, we convert our
 # static list to use dashes as well for the negotiation.
 LOCALE_STRINGS_DASH = map(lambda l: string.replace(l, '_', '-'),
                           LOCALE_STRINGS)
+
+# We have only Brazilian Portuguese, so we show that when pt is requested.
+A2_LOCALE_ALIASES = LOCALE_ALIASES.copy()
+A2_LOCALE_ALIASES['pt'] = 'pt_BR'
 
 FALLBACK_TZ = 'Europe/Berlin'
 
@@ -123,7 +125,8 @@ def user_language(user, fallbacks=[]):
 
     if locale is None:
         locale = Locale.parse(Locale.negotiate(fallbacks, LOCALE_STRINGS_DASH,
-                                               sep='-')) \
+                                               sep='-',
+                                               aliases=A2_LOCALE_ALIASES)) \
             or get_default_locale()
 
     # determinate from which path we load the translations


### PR DESCRIPTION
#894 was only partly correct:

The previous "fix" of adding {'pt':'pt_BR'} as locale alias actually replaced the
original babel alias dict and therefore only had the intended effect by accident
and only Portuguese survived the babel language negotiation process!

The real problem was that Babel language negotiation can only compare
language codes using the same separator. As we use underscores and
browsers send dashes, we now convert our static list to use dashes as well
for the negotiation.

In the second commit the LOCALE_ALIASES feature is used in order to make
Brazilian (and not English or whatever) show up if Portuguese is requested.
