### PR TITLE
allow to link to inline rows

### DIFF
--- a/src/adhocracy/static/javascripts/adhocracy.js
+++ b/src/adhocracy/static/javascripts/adhocracy.js
@@ -1411,4 +1411,8 @@ $(document).ready(function () {
     );
 
     adhocracy.helpers.relative_time($('time.relative'));
+
+    // expand inline rows on direct links
+    // :target does not work for some reason, so we use window.location.hash
+    $(window.location.hash).find('.row_button a').click();
 });

--- a/src/adhocracy/templates/proposal/tiles.html
+++ b/src/adhocracy/templates/proposal/tiles.html
@@ -50,7 +50,7 @@
 
 
 <%def name="row(tile, proposal)">
-    <li class="content_box ${'fresh' if tile.fresh else ''} proposal-row">
+    <li class="content_box ${'fresh' if tile.fresh else ''} proposal-row" id="proposal-${proposal.id}">
         <div class="main_row">
             ${_row(tile, proposal)}
         </div>
@@ -59,19 +59,19 @@
 
 
 <%def name="row_inline(tile, proposal)">
-    <li class="content_box ${'fresh' if tile.fresh else ''} proposal-row-inline">
+    <li class="content_box ${'fresh' if tile.fresh else ''} proposal-row-inline" id="proposal-${proposal.id}">
         <div class="main_row">
             <div class="row_button">
                 <a class="button_small showhide_button content"
-                   data-target="#proposal-${proposal.id}"
-                   aria-controls="proposal-${proposal.id}"
+                   data-target="#proposal-${proposal.id}-detail"
+                   aria-controls="proposal-${proposal.id}-detail"
                    data-target-speed="fast"
                    data-toggle-class="less"
-                   href="#"></a>
+                   href="#proposal-${proposal.id}"></a>
             </div>
             ${_row(tile, proposal)}
         </div>
-        <article class="proposal" style="display: none" id="proposal-${proposal.id}">
+        <article class="proposal" style="display: none" id="proposal-${proposal.id}-detail">
             <div class="body">
                 ${tiles.page.inline(proposal.description)}
             </div>


### PR DESCRIPTION
This allows to link to proposal pager rows. On inline rows (see #733) it also expands the row. The link is available from the expand button.

The javascript expands the row on page load. If I just change the fragment, no reload is triggered and so the javascript is not executed. This could be fixed using the [hashchange event](https://developer.mozilla.org/en-US/docs/Web/Reference/Events/hashchange).

JQuery's [`:target`](http://api.jquery.com/target-selector/) selector did not work for some reason so I fell back to [window.location](https://developer.mozilla.org/en-US/docs/Web/API/Window.location) which is currently not supported in IE. I guess this is acceptable in this case.
