### PR TITLE
avoid multiple submits (e.g. double-click)

### DIFF
--- a/src/adhocracy/static/javascripts/adhocracy.js
+++ b/src/adhocracy/static/javascripts/adhocracy.js
@@ -1429,4 +1429,10 @@ $(document).ready(function () {
     // expand inline rows on direct links
     // :target does not work for some reason, so we use window.location.hash
     $(window.location.hash).find('.row_button a').click();
+
+    // avoid multiple submits (e.g. double-click)
+    $('html').on('submit', 'form', function(e) {
+        $(this).find('submit').prop("disabled", true);
+        $(this).find('[type="submit"]').prop("disabled", true);
+    });
 });


### PR DESCRIPTION
Many users use double-clicks on the internet. This is not a problem with links, but it is often a problem with submit. This is a small fix that disables submit buttons when a submit is triggered. It should not collide with anything.
