### PR TITLE
Raise meaningful exception if amendment doesn't have a selection.

### DIFF
--- a/src/adhocracy/model/proposal.py
+++ b/src/adhocracy/model/proposal.py
@@ -40,7 +40,12 @@ class Proposal(Delegateable):
     @property
     def selection(self):
         assert(self.is_amendment)
-        return self._selections[0]
+        try:
+            return self._selections[0]
+        except IndexError:
+            raise Exception(
+                'Proposal %d is amendment but doesn\'t have selections'
+                % self.id)
 
     @property
     def title(self):


### PR DESCRIPTION
Such broken data exists due to a previous bug. This makes it easier to
detect that.
