### PR TITLE
Allow to log to sentry server

### DIFF
--- a/buildouts/adhocracy.cfg
+++ b/buildouts/adhocracy.cfg
@@ -19,6 +19,7 @@ eggs +=
     BeautifulSoup
     fanstatic
     ipython
+    raven
 # checkout adhocracy packages to ./src
 auto-checkout = *
 # supervisor config to start adhocracy
@@ -61,6 +62,10 @@ debug = False
 geo = False
 # theme adhocracy with diazo and merge a wordpress blog.
 themed = False
+
+# log to an external sentry server
+sentry.enabled = False
+# sentry.dsn =
 
 protocol = http
 host = 127.0.0.1

--- a/etc/adhocracy.ini.in
+++ b/etc/adhocracy.ini.in
@@ -620,18 +620,45 @@ script_location = src/adhocracy/alembic
 sqlalchemy.url = ${parts.adhocracy['sqlalchemy.url']}
 
 # Logging configuration
+
+{% if parts.adhocracy['sentry.enabled'] == 'True' %}
+[loggers]
+keys = root, adhocracy, sqlalchemy, sentry
+
+[handlers]
+keys = console, sentry
+
+[logger_root]
+level = INFO
+handlers = console, sentry
+
+[logger_sentry]
+level = WARN
+handlers = console
+qualname = sentry.errors
+propagate = 0
+
+[handler_sentry]
+class = raven.handlers.logging.SentryHandler
+args = ('${parts.adhocracy["sentry.dsn"]}',)
+level = WARN
+formatter = generic
+{% end %}
+
+{% if parts.adhocracy['sentry.enabled'] == 'False' %}
 [loggers]
 keys = root, adhocracy, sqlalchemy
 
 [handlers]
 keys = console
 
-[formatters]
-keys = generic
-
 [logger_root]
 level = INFO
 handlers = console
+{% end %}
+
+[formatters]
+keys = generic
 
 [logger_routes]
 level = INFO


### PR DESCRIPTION
In order to log to an external sentry server, set the following options
to the [adhocracy] section of your buildout.cfg:

sentry.enabled = True
sentry.dsn = https://blabla
