### PR TITLE
allow to hide milestone timeline

### DIFF
--- a/etc/adhocracy.ini.in
+++ b/etc/adhocracy.ini.in
@@ -558,6 +558,9 @@ velruse.port = ${parts.ports.velruse_proxy}
 velruse.protocol = ${parts.velruse.proxy_protocol}
 {% end %}
 
+# hide milestone timeline
+# adhocracy.milestone.hide_timeline = True
+
 
 # The following settings lack documentation
 

--- a/src/adhocracy/config/__init__.py
+++ b/src/adhocracy/config/__init__.py
@@ -84,6 +84,8 @@ DEFAULTS = {
     # 'default' or 'alternate'
     'adhocracy.login_style': 'default',
     'adhocracy.milestone.allow_show_all_proposals': False,
+    'adhocracy.milestone.hide_timeline': False,
+    'adhocracy.milestone.hide_timeline.allow_overwrite': True,
     'adhocracy.monitor_browser_values': False,
     'adhocracy.monitor_comment_behavior': False,
     'adhocracy.monitor_extended': False,

--- a/src/adhocracy/templates/milestone/index.html
+++ b/src/adhocracy/templates/milestone/index.html
@@ -19,7 +19,9 @@
 
 <hr />
 
+%if not h.config.get('adhocracy.milestone.hide_timeline'):
 ${tiles.milestone.timeline(c.milestones)}
+%endif
 
 </%block>
 


### PR DESCRIPTION
This adds the installation setting `adhocracy.milestone.hide_timeline` (`allow_overwrite` by default) to hide the milestone timeline.
