### PR TITLE
No email uniqueness on database level (fixes #790, #364)

### DIFF
--- a/src/adhocracy/alembic/versions/266ab139e8ab_no_email_uniqueness_on_database_level.py
+++ b/src/adhocracy/alembic/versions/266ab139e8ab_no_email_uniqueness_on_database_level.py
@@ -1,0 +1,21 @@
+"""No email uniqueness on database level
+
+Revision ID: 266ab139e8ab
+Revises: 1e296c7f5e8c
+Create Date: 2014-07-18 14:55:17.188121
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '266ab139e8ab'
+down_revision = '1e296c7f5e8c'
+
+from alembic import op
+
+
+def upgrade():
+    op.drop_constraint(u'user_email_key', 'user')
+
+
+def downgrade():
+    op.create_unique_constraint(u'user_email_key', 'user', ['email'])

--- a/src/adhocracy/model/user.py
+++ b/src/adhocracy/model/user.py
@@ -27,7 +27,7 @@ user_table = Table(
     Column('user_name', Unicode(255), nullable=False, unique=True, index=True),
     Column('display_name', Unicode(255), nullable=True, index=True),
     Column('bio', UnicodeText(), nullable=True),
-    Column('email', Unicode(255), nullable=True, unique=True),
+    Column('email', Unicode(255), nullable=True, unique=False),
     Column('email_priority', Integer, default=3),
     Column('activation_code', Unicode(255), nullable=True, unique=False),
     Column('reset_code', Unicode(255), nullable=True, unique=False),


### PR DESCRIPTION
Due to #363, users which have been deleted could not create another account with the same email address if the email must be unique in databases. This PR relaxes this constraint.
