### PR TITLE
Show short category description in category description view

### DIFF
--- a/src/adhocracy/controllers/category.py
+++ b/src/adhocracy/controllers/category.py
@@ -90,13 +90,9 @@ class CategoryController(BaseController):
             abort(404)
         category = get_entity_or_abort(model.CategoryBadge, id)
 
-        description = category.long_description
-        description = h.render(description)
-        description = h.text.truncate_html(description, 65, u'&hellip;')
-
         data = {
             'category': category,
-            'description': description,
+            'description': category.description,
         }
         return render('/category/description.html', data,
                       overlay=format == 'overlay',

--- a/src/adhocracy/templates/category/description.html
+++ b/src/adhocracy/templates/category/description.html
@@ -3,7 +3,7 @@
 
 <%block name="main_content">
 <div class="category_body">
-    ${c.description|n}
+    ${c.description}
     <a class="more_link" href="${h.entity_url(c.category)}">${_('more')}</a>
 </div>
 </%block>


### PR DESCRIPTION
This view is ment to be embedded. But the height of the long description
can vary in height because it can contain e.g. images. So instead we use
the short description which has a limit of 255 chars and no
HTML/markdown.
