### PR TITLE
Fix AuthCheck.propose_login

### DIFF
--- a/src/adhocracy/lib/auth/authorization.py
+++ b/src/adhocracy/lib/auth/authorization.py
@@ -19,6 +19,7 @@ log = logging.getLogger(__name__)
 
 
 NOT_LOGGED_IN = 'not_logged_in'
+NOT_JOINED = 'user_is_no_member'
 
 
 class InstanceGroupSourceAdapter(SqlGroupsAdapter):
@@ -173,8 +174,8 @@ class AuthCheck(object):
         """
         return (self.permission_refusals
                 and (not self.other_refusals or
-                     (len(self.other_refusals) == 1
-                      and NOT_LOGGED_IN in self.other_refusals))
+                     all(map(lambda e: e in [NOT_LOGGED_IN, NOT_JOINED],
+                             self.other_refusals)))
                 and all(has_default_permission(perm).is_met(request.environ)
                         for perm in self.permission_refusals))
 

--- a/src/adhocracy/lib/auth/instance.py
+++ b/src/adhocracy/lib/auth/instance.py
@@ -1,5 +1,6 @@
 from pylons import tmpl_context as c, app_globals as g
 from authorization import has
+from adhocracy.lib.auth.authorization import NOT_JOINED
 from adhocracy.lib.auth.authorization import NOT_LOGGED_IN
 
 
@@ -75,7 +76,7 @@ def leave(check, i):
     check.perm('instance.leave')
     check.other('not_logged_in', not c.user)
     if c.user:
-        check.other('user_is_no_member', not c.user.is_member(i))
+        check.other(NOT_JOINED, not c.user.is_member(i))
         check.other('user_is_instance_creator', c.user == i.creator)
 
 

--- a/src/adhocracy/lib/auth/proposal.py
+++ b/src/adhocracy/lib/auth/proposal.py
@@ -2,6 +2,7 @@ from pylons import tmpl_context as c
 
 from adhocracy.lib.auth import poll
 from adhocracy.lib.auth.authorization import has
+from adhocracy.lib.auth.authorization import NOT_JOINED
 
 
 # helper functions
@@ -26,8 +27,7 @@ def create(check, instance=None):
     check.valid_email()
     if instance is None:
         instance = c.instance
-    check.other('user_is_no_member', not c.user or
-                not c.user.is_member(instance))
+    check.other(NOT_JOINED, not c.user or not c.user.is_member(instance))
     check.other('instance_frozen', instance.frozen)
     check.perm('proposal.create')
 
@@ -45,8 +45,7 @@ def edit(check, p):
         # having proposal.edit is enough
         return
 
-    check.other('user_is_no_member', not c.user or
-                not c.user.is_member(c.instance))
+    check.other(NOT_JOINED, not c.user or not c.user.is_member(c.instance))
     check.other('proposal_head_not_wiki_or_own',
                 not is_own(p) and not p.description.head.wiki)
 


### PR DESCRIPTION
We now propose login if all permission refusals are due to not being
logged in or not being a member of this instance.

This is relevant due to the more restrictive membership checks in
5205fa1db0a11b42b0a3db80cb5ad5ed6917577d and
4cfefbe2920f276357462da424a8d7baa038d0e7.

Practically this means that by default the "new proposal" button / link
is now displayed again for non-logged-in users, and that if they visit
`/proposal/new` (that link), they're now redirected to the login page
instead of getting a 403.
