### PR TITLE
Fix came_from encoding after register

### DIFF
--- a/src/adhocracy/controllers/user.py
+++ b/src/adhocracy/controllers/user.py
@@ -332,7 +332,7 @@ class UserController(BaseController):
                 {'site_name': config.get('adhocracy.site.name')},
                 category='success')
 
-            raise HTTPFound(location=location, headers=headers)
+            raise HTTPFound(location=location.encode('utf-8'), headers=headers)
         else:
             raise Exception('We have added the user to the Database '
                             'but cannot authenticate him: '


### PR DESCRIPTION
While pylons.controllers.util.redirect utf8-encodes the given location,
webob.exc.HTTPFound doesn't, so we need to do that manually.
