### PR TITLE
Drop support for Python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-    - "2.6"
     - "2.7"
 install: ./build.sh
 script: cd adhocracy_buildout && bin/test

--- a/INSTALLATION.rst
+++ b/INSTALLATION.rst
@@ -86,8 +86,8 @@ Check out Adhocracy:
 
 Setup an isolated python environment to run Adhocracy
 `````````````````````````````````````````````````````
-To install Adhocracy you need python (2.6|2.7) with PIL (python imaging) but
-no other system-packages.
+To install Adhocracy you need python 2.7 with PIL (python imaging) but no other
+system-packages.
 
 Compile python and PIL with the included python buildout::
 


### PR DESCRIPTION
All major distributions have Python 2.7 nowadays and we haven't tested
Adhocracy with Python 2.6 for a long time. Furthermore the CI fails.